### PR TITLE
Replaces `search` with `coordinates`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.5)
+    mas-rad_core (0.0.6)
       geocoder
       pg
       rails (~> 4.2.0)

--- a/app/jobs/geocode_firm_job.rb
+++ b/app/jobs/geocode_firm_job.rb
@@ -2,20 +2,7 @@ require 'geocoder'
 
 class GeocodeFirmJob < ActiveJob::Base
   def perform(firm)
-    results = Geocoder.search(firm.full_street_address)
-
-    if results.any?
-      stat :success
-      firm.geocode!(results.first.latitude, results.first.longitude)
-    else
-      stat :failed
-      firm.geocode!
-    end
-  end
-
-  private
-
-  def stat(key)
-    Stats.increment("radsignup.geocode_firm.#{key}")
+    coordinates = Geocoder.coordinates(firm.full_street_address)
+    firm.geocode!(coordinates)
   end
 end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.5'
+    VERSION = '0.0.6'
   end
 end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -229,57 +229,18 @@ RSpec.describe Firm do
     end
   end
 
-  describe '#latitude=' do
-    let(:firm) { create(:firm) }
-    let(:latitude) { Faker::Address.latitude }
-
-    before { firm.latitude = latitude }
-
-    it 'casts the value to a float rounded to six decimal places' do
-      expect(firm.latitude).to eql(latitude.to_f.round(6))
-    end
-
-    context 'when the value is nil' do
-      let(:latitude) { nil }
-
-      it 'does not cast the value' do
-        expect(firm.latitude).to be_nil
-      end
-    end
-  end
-
-  describe '#longitude=' do
-    let(:firm) { create(:firm) }
-    let(:longitude) { Faker::Address.longitude }
-
-    before { firm.longitude = longitude }
-
-    it 'casts the value to a float rounded to six decimal places' do
-      expect(firm.longitude).to eql(longitude.to_f.round(6))
-    end
-
-    context 'when the value is nil' do
-      let(:longitude) { nil }
-
-      it 'does not cast the value' do
-        expect(firm.longitude).to be_nil
-      end
-    end
-  end
-
   describe '#geocode!' do
     let(:firm) { create(:firm) }
-    let(:latitude) { Faker::Address.latitude }
-    let(:longitude) { Faker::Address.longitude }
+    let(:coordinates) { [Faker::Address.latitude, Faker::Address.longitude] }
 
     it 'does not schedule the firm for geocoding' do
       expect(GeocodeFirmJob).not_to receive(:perform_later)
-      firm.geocode!(latitude, longitude)
+      firm.geocode!(coordinates)
     end
 
     context 'after the geocode is complete' do
       before do
-        firm.geocode!(latitude, longitude)
+        firm.geocode!(coordinates)
         firm.reload
       end
 
@@ -288,8 +249,8 @@ RSpec.describe Firm do
       end
 
       it 'the latitude and longitude attributes are updated' do
-        expect(firm.latitude).to eql(latitude.to_f.round(6))
-        expect(firm.longitude).to eql(longitude.to_f.round(6))
+        expect(firm.latitude).to  eql(coordinates[0].to_f.round(6))
+        expect(firm.longitude).to eql(coordinates[1].to_f.round(6))
       end
     end
   end


### PR DESCRIPTION
Also moved a bunch of stuff around to reduce the logic in the job which is now
just responsible for retrieving the coordinates and handing off to the `Firm`.

@lshepstone WDYT? I went a little crazy. I'm perfectly happy to reduce this
down to just what we needed for `coordinates` if you think it was a step too
far?