### PR TITLE
Adds lat/long pair to `Adviser`

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -2,7 +2,7 @@
 # This command will automatically be run when you run "rails" with Rails 4 gems installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/rad_core/engine', __FILE__)
+ENGINE_PATH = File.expand_path('../../lib/mas/rad_core/engine', __FILE__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)

--- a/db/migrate/20150222092417_add_latitude_and_longitude_to_advisers.rb
+++ b/db/migrate/20150222092417_add_latitude_and_longitude_to_advisers.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToAdvisers < ActiveRecord::Migration
+  def change
+    add_column :advisers, :latitude, :float
+    add_column :advisers, :longitude, :float
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,11 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150210113610) do
+ActiveRecord::Schema.define(version: 20150222092417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -40,6 +39,8 @@ ActiveRecord::Schema.define(version: 20150210113610) do
     t.boolean  "confirmed_disclaimer",              null: false
     t.string   "postcode",             default: "", null: false
     t.integer  "travel_distance",      default: 0,  null: false
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   create_table "advisers_professional_bodies", id: false, force: :cascade do |t|

--- a/spec/factories/adviser.rb
+++ b/spec/factories/adviser.rb
@@ -6,6 +6,8 @@ FactoryGirl.define do
     name 'Ben Lovell'
     postcode 'RG1 1NN'
     travel_distance '50'
+    latitude  { Faker::Address.latitude.to_f.round(6) }
+    longitude { Faker::Address.longitude.to_f.round(6) }
     confirmed_disclaimer true
     firm
 


### PR DESCRIPTION
I'm just stubbing out these values for now, while @lshepstone works on getting
`Adviser` geocoded in the background. Rather than us both land on these fields
independently I decided to get them in real quick.