### PR TITLE
5853 Geocode Advisers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.5)
+    mas-rad_core (0.0.6)
       geocoder
       pg
       rails (~> 4.2.0)

--- a/app/jobs/geocode_adviser_job.rb
+++ b/app/jobs/geocode_adviser_job.rb
@@ -1,0 +1,15 @@
+require 'geocoder'
+
+class GeocodeAdviserJob < ActiveJob::Base
+  def perform(adviser)
+    point = Geocoder.coordinates(adviser.full_street_address)
+    point ? stat(:success) : stat(:failed)
+    adviser.geocode!(point)
+  end
+
+  private
+
+  def stat(key)
+    Stats.increment("radsignup.geocode_adviser.#{key}")
+  end
+end

--- a/app/jobs/geocode_adviser_job.rb
+++ b/app/jobs/geocode_adviser_job.rb
@@ -1,5 +1,3 @@
-require 'geocoder'
-
 class GeocodeAdviserJob < ActiveJob::Base
   def perform(adviser)
     coordinates = Geocoder.coordinates(adviser.full_street_address)

--- a/app/jobs/geocode_adviser_job.rb
+++ b/app/jobs/geocode_adviser_job.rb
@@ -10,6 +10,6 @@ class GeocodeAdviserJob < ActiveJob::Base
   private
 
   def stat(key)
-    Stats.increment("radsignup.geocode_adviser.#{key}")
+    Stats.increment("radsignup.geocode.adviser.#{key}")
   end
 end

--- a/app/jobs/geocode_adviser_job.rb
+++ b/app/jobs/geocode_adviser_job.rb
@@ -2,9 +2,9 @@ require 'geocoder'
 
 class GeocodeAdviserJob < ActiveJob::Base
   def perform(adviser)
-    point = Geocoder.coordinates(adviser.full_street_address)
-    point ? stat(:success) : stat(:failed)
-    adviser.geocode!(point)
+    coordinates = Geocoder.coordinates(adviser.full_street_address)
+    coordinates ? stat(:success) : stat(:failed)
+    adviser.geocode!(coordinates)
   end
 
   private

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -45,8 +45,8 @@ class Adviser < ActiveRecord::Base
     write_attribute(:longitude, value)
   end
 
-  def geocode!(coordinate)
-    self.latitude, self.longitude = coordinate
+  def geocode!(coordinates)
+    self.latitude, self.longitude = coordinates
     save!(callbacks: false)
   end
 

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -29,6 +29,8 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
+  after_save :geocode_if_needed
+
   def full_street_address
     [postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')
   end
@@ -43,6 +45,12 @@ class Adviser < ActiveRecord::Base
   end
 
   private
+
+  def geocode_if_needed
+    if valid? && postcode_changed?
+      GeocodeAdviserJob.perform_later(self)
+    end
+  end
 
   def upcase_postcode
     postcode.upcase! if postcode.present?

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -1,5 +1,5 @@
 class Adviser < ActiveRecord::Base
-  include Geocode
+  include Geocodable
 
   belongs_to :firm
 

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -45,6 +45,11 @@ class Adviser < ActiveRecord::Base
     write_attribute(:longitude, value)
   end
 
+  def geocode!(coordinate)
+    self.latitude, self.longitude = coordinate
+    save!(callbacks: false)
+  end
+
   def field_order
     [
       :reference_number,

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -32,7 +32,7 @@ class Adviser < ActiveRecord::Base
   after_save :geocode_if_needed
 
   def full_street_address
-    [postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')
+    "#{postcode}, United Kingdom"
   end
 
   def latitude=(value)

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -1,4 +1,6 @@
 class Adviser < ActiveRecord::Base
+  include Geocode
+
   belongs_to :firm
 
   has_and_belongs_to_many :qualifications
@@ -33,21 +35,6 @@ class Adviser < ActiveRecord::Base
 
   def full_street_address
     "#{postcode}, United Kingdom"
-  end
-
-  def latitude=(value)
-    value = value.to_f.round(6) unless value.nil?
-    write_attribute(:latitude, value)
-  end
-
-  def longitude=(value)
-    value = value.to_f.round(6) unless value.nil?
-    write_attribute(:longitude, value)
-  end
-
-  def geocode!(coordinates)
-    self.latitude, self.longitude = coordinates
-    save!(callbacks: false)
   end
 
   def field_order

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -35,6 +35,16 @@ class Adviser < ActiveRecord::Base
     [postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')
   end
 
+  def latitude=(value)
+    value = value.to_f.round(6) unless value.nil?
+    write_attribute(:latitude, value)
+  end
+
+  def longitude=(value)
+    value = value.to_f.round(6) unless value.nil?
+    write_attribute(:longitude, value)
+  end
+
   def field_order
     [
       :reference_number,

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -29,6 +29,10 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
+  def full_street_address
+    [postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')
+  end
+
   def field_order
     [
       :reference_number,

--- a/app/models/geocodable.rb
+++ b/app/models/geocodable.rb
@@ -1,4 +1,4 @@
-module Geocode
+module Geocodable
   def latitude=(value)
     value = value.to_f.round(6) unless value.nil?
     write_attribute(:latitude, value)

--- a/app/models/geocode.rb
+++ b/app/models/geocode.rb
@@ -1,0 +1,16 @@
+module Geocode
+  def latitude=(value)
+    value = value.to_f.round(6) unless value.nil?
+    write_attribute(:latitude, value)
+  end
+
+  def longitude=(value)
+    value = value.to_f.round(6) unless value.nil?
+    write_attribute(:longitude, value)
+  end
+
+  def geocode!(coordinates)
+    self.latitude, self.longitude = coordinates
+    save!(callbacks: false)
+  end
+end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.5'
+    VERSION = '0.0.6'
   end
 end

--- a/spec/factories/adviser.rb
+++ b/spec/factories/adviser.rb
@@ -11,6 +11,9 @@ FactoryGirl.define do
     confirmed_disclaimer true
     firm
 
+    before(:create) { |a| a.class.skip_callback(:save, :after, :geocode_if_needed) }
+    after(:create) { |a| a.class.set_callback(:save, :after, :geocode_if_needed) }
+
     after(:build) do |a|
       if a.reference_number?
         Lookup::Adviser.create!(

--- a/spec/fixtures/vcr_cassettes/postcode-no-results.yml
+++ b/spec/fixtures/vcr_cassettes/postcode-no-results.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=ABC%20123,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 23 Feb 2015 10:25:12 GMT
+      Expires:
+      - Tue, 24 Feb 2015 10:25:12 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Alternate-Protocol:
+      - 80:quic,p=0.08
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [],
+           "status" : "ZERO_RESULTS"
+        }
+    http_version: 
+  recorded_at: Mon, 23 Feb 2015 10:25:12 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/postcode-one-result.yml
+++ b/spec/fixtures/vcr_cassettes/postcode-one-result.yml
@@ -1,0 +1,114 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 23 Feb 2015 10:26:05 GMT
+      Expires:
+      - Tue, 24 Feb 2015 10:26:05 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Alternate-Protocol:
+      - 80:quic,p=0.08
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC1N 2TD, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5182639,
+                          "lng" : -0.1078729
+                       },
+                       "southwest" : {
+                          "lat" : 51.5173261,
+                          "lng" : -0.1094075
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.5180697,
+                       "lng" : -0.1085203
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5191439802915,
+                          "lng" : -0.107291219708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5164460197085,
+                          "lng" : -0.109989180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ5_7trE0bdkgRKFWaw55y3rM",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Mon, 23 Feb 2015 10:26:05 GMT
+recorded_with: VCR 2.9.3

--- a/spec/jobs/geocode_adviser_job_spec.rb
+++ b/spec/jobs/geocode_adviser_job_spec.rb
@@ -1,0 +1,31 @@
+require 'geocoder'
+
+RSpec.describe GeocodeAdviserJob do
+  let(:job) { GeocodeAdviserJob.new }
+
+  subject(:adviser) { create(:adviser, postcode: postcode) }
+
+  describe '#perform' do
+    context 'when the adviser postcode can be geocoded' do
+      let(:postcode) { 'EC1N 2TD' }
+
+      it 'the adviser is geocoded with the coordinates' do
+        VCR.use_cassette('postcode-one-result') do
+          expect(adviser).to receive(:geocode!).with([51.5180697, -0.1085203])
+          job.perform(adviser)
+        end
+      end
+    end
+
+    context 'when adviser postcode cannot be geocoded' do
+      let(:postcode) { 'ABC 123' }
+
+      it 'the latitude and longitude are set to nil' do
+        VCR.use_cassette('postcode-no-results') do
+          expect(adviser).to receive(:geocode!).with(nil)
+          job.perform(adviser)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/geocode_adviser_job_spec.rb
+++ b/spec/jobs/geocode_adviser_job_spec.rb
@@ -1,5 +1,3 @@
-require 'geocoder'
-
 RSpec.describe GeocodeAdviserJob do
   let(:job) { GeocodeAdviserJob.new }
 

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -90,4 +90,11 @@ RSpec.describe Adviser do
       end
     end
   end
+
+  describe '#full_street_address' do
+    let(:adviser) { create(:adviser) }
+    subject { adviser.full_street_address }
+
+    it { is_expected.to eql "#{adviser.postcode}, United Kingdom"}
+  end
 end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -138,11 +138,11 @@ RSpec.describe Adviser do
 
   describe '#geocode!' do
     let(:adviser) { create(:adviser) }
-    let(:coordinate) { [Faker::Address.latitude, Faker::Address.longitude] }
+    let(:coordinates) { [Faker::Address.latitude, Faker::Address.longitude] }
 
     before do
       expect(GeocodeFirmJob).not_to receive(:perform_later)
-      adviser.geocode!(coordinate)
+      adviser.geocode!(coordinates)
       adviser.reload
     end
 
@@ -150,18 +150,18 @@ RSpec.describe Adviser do
       expect(adviser).to be_persisted
     end
 
-    context 'with a valid coordinate' do
+    context 'with valid coordinates' do
       it 'the adviser latitude is updated' do
-        expect(adviser.latitude).to eql(coordinate.first.to_f.round(6))
+        expect(adviser.latitude).to eql(coordinates.first.to_f.round(6))
       end
 
       it 'the adviser longitude is updated' do
-        expect(adviser.longitude).to eql(coordinate.last.to_f.round(6))
+        expect(adviser.longitude).to eql(coordinates.last.to_f.round(6))
       end
     end
 
-    context 'with no coordinate' do
-      let(:coordinate) { nil }
+    context 'with no coordinates' do
+      let(:coordinates) { nil }
 
       it 'the adviser latitude is updated' do
         expect(adviser.latitude).to be_nil

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -136,6 +136,43 @@ RSpec.describe Adviser do
     end
   end
 
+  describe '#geocode!' do
+    let(:adviser) { create(:adviser) }
+    let(:coordinate) { [Faker::Address.latitude, Faker::Address.longitude] }
+
+    before do
+      expect(GeocodeFirmJob).not_to receive(:perform_later)
+      adviser.geocode!(coordinate)
+      adviser.reload
+    end
+
+    it 'the adviser is persisted' do
+      expect(adviser).to be_persisted
+    end
+
+    context 'with a valid coordinate' do
+      it 'the adviser latitude is updated' do
+        expect(adviser.latitude).to eql(coordinate.first.to_f.round(6))
+      end
+
+      it 'the adviser longitude is updated' do
+        expect(adviser.longitude).to eql(coordinate.last.to_f.round(6))
+      end
+    end
+
+    context 'with no coordinate' do
+      let(:coordinate) { nil }
+
+      it 'the adviser latitude is updated' do
+        expect(adviser.latitude).to be_nil
+      end
+
+      it 'the adviser longitude is updated' do
+        expect(adviser.longitude).to be_nil
+      end
+    end
+  end
+
   describe 'after save' do
     let(:adviser) { build(:adviser) }
 

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -97,4 +97,35 @@ RSpec.describe Adviser do
 
     it { is_expected.to eql "#{adviser.postcode}, United Kingdom"}
   end
+
+  describe 'after save' do
+    let(:adviser) { build(:adviser) }
+
+    context 'when the postcode is present' do
+      it 'the adviser is scheduled for geocoding' do
+        expect(GeocodeAdviserJob).to receive(:perform_later).with(adviser)
+        adviser.save!
+      end
+    end
+
+    context 'when the adviser is not valid' do
+      before { adviser.postcode = 'not-valid' }
+
+      it 'the adviser is not scheduled for geocoding' do
+        expect(GeocodeAdviserJob).not_to receive(:perform_later)
+        adviser.save!(validate: false)
+      end
+    end
+
+    context 'when the postcode has changed' do
+      let(:adviser) { create(:adviser) }
+
+      before { adviser.postcode = 'ABCD 123' }
+
+      it 'the adviser is scheduled for geocoding' do
+        expect(GeocodeAdviserJob).to receive(:perform_later).with(adviser)
+        adviser.save!
+      end
+    end
+  end
 end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -98,6 +98,44 @@ RSpec.describe Adviser do
     it { is_expected.to eql "#{adviser.postcode}, United Kingdom"}
   end
 
+  describe '#latitude=' do
+    let(:adviser) { create(:adviser) }
+    let(:latitude) { Faker::Address.latitude }
+
+    before { adviser.latitude = latitude }
+
+    it 'casts the value to a float rounded to six decimal places' do
+      expect(adviser.latitude).to eql(latitude.to_f.round(6))
+    end
+
+    context 'when the value is nil' do
+      let(:latitude) { nil }
+
+      it 'does not cast the value' do
+        expect(adviser.latitude).to be_nil
+      end
+    end
+  end
+
+  describe '#longitude=' do
+    let(:adviser) { create(:adviser) }
+    let(:longitude) { Faker::Address.longitude }
+
+    before { adviser.longitude = longitude }
+
+    it 'casts the value to a float rounded to six decimal places' do
+      expect(adviser.longitude).to eql(longitude.to_f.round(6))
+    end
+
+    context 'when the value is nil' do
+      let(:longitude) { nil }
+
+      it 'does not cast the value' do
+        expect(adviser.longitude).to be_nil
+      end
+    end
+  end
+
   describe 'after save' do
     let(:adviser) { build(:adviser) }
 


### PR DESCRIPTION
The approach is largely the same as that for firms, except that this uses Geocoder's coordinate search and passes the lat/long pair as a single argument to the adviser's `geocode!` method. Also, the seam for the GeocodeAdviserJob spec is limited to calling the `geocode!` method, and doesn't check that the lat/long attributes were set - that's covered in the adviser spec for `geocode!`.

I've left the lat/long sanitising methods in here, we can chat about a better way forward there.

@benlovell