### PR TITLE
Translatable Reference Data

### DIFF
--- a/app/models/other_advice_method.rb
+++ b/app/models/other_advice_method.rb
@@ -1,4 +1,6 @@
 class OtherAdviceMethod < ActiveRecord::Base
+  include Translatable
+
   has_and_belongs_to_many :firms
 
   validates_presence_of :name

--- a/app/models/translatable.rb
+++ b/app/models/translatable.rb
@@ -1,7 +1,5 @@
 module Translatable
-  def en_name
-    self.name
-  end
+  alias_attribute :en_name, :name
 
   def localized_name
     case I18n.locale

--- a/app/models/translatable.rb
+++ b/app/models/translatable.rb
@@ -1,0 +1,14 @@
+module Translatable
+  def en_name
+    self.name
+  end
+
+  def localized_name
+    case I18n.locale
+      when :en
+        en_name
+      when :cy
+        cy_name
+    end || name
+  end
+end

--- a/app/models/translatable.rb
+++ b/app/models/translatable.rb
@@ -3,10 +3,10 @@ module Translatable
 
   def localized_name
     case I18n.locale
-      when :en
-        en_name
-      when :cy
-        cy_name
-    end || name
+    when :en
+      en_name
+    when :cy
+      cy_name
+    end
   end
 end

--- a/db/migrate/20150228095315_add_cy_name_to_other_advice_methods.rb
+++ b/db/migrate/20150228095315_add_cy_name_to_other_advice_methods.rb
@@ -1,0 +1,5 @@
+class AddCyNameToOtherAdviceMethods < ActiveRecord::Migration
+  def change
+    add_column :other_advice_methods, :cy_name, :string
+  end
+end

--- a/spec/dummy/config/locales/cy.yml
+++ b/spec/dummy/config/locales/cy.yml
@@ -1,0 +1,2 @@
+cy:
+  hello: "Hello world"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150222092417) do
+ActiveRecord::Schema.define(version: 20150228095315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -207,6 +207,7 @@ ActiveRecord::Schema.define(version: 20150222092417) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.integer  "order",      default: 0, null: false
+    t.string   "cy_name"
   end
 
   create_table "principals", force: :cascade do |t|

--- a/spec/factories/other_advice_method.rb
+++ b/spec/factories/other_advice_method.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :other_advice_method do
     name { Faker::Lorem.sentence }
+    sequence(:cy_name) { |n| "Dull gyngor arall #{n}" }
   end
 end

--- a/spec/factories/other_advice_method.rb
+++ b/spec/factories/other_advice_method.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :other_advice_method do
     name { Faker::Lorem.sentence }
-    sequence(:cy_name) { |n| "Dull gyngor arall #{n}" }
+    cy_name { Faker::Lorem.sentence }
   end
 end

--- a/spec/models/other_advice_method_spec.rb
+++ b/spec/models/other_advice_method_spec.rb
@@ -1,3 +1,4 @@
 RSpec.describe OtherAdviceMethod do
   it_behaves_like 'reference data'
+  it_behaves_like 'translatable'
 end

--- a/spec/support/shared_examples/translatable_examples.rb
+++ b/spec/support/shared_examples/translatable_examples.rb
@@ -14,18 +14,8 @@ RSpec.shared_examples 'translatable' do
         I18n.with_locale(:cy) { example.run }
       end
 
-      context 'and a value for cy_name is present' do
-        it 'returns the value for cy_name' do
-          expect(model.localized_name).to eql(model.cy_name)
-        end
-      end
-
-      context 'and a value for cy_name is not present' do
-        before { model.cy_name = nil }
-
-        it 'returns the value for name' do
-          expect(model.localized_name).to eql(model.name)
-        end
+      it 'returns the value for cy_name' do
+        expect(model.localized_name).to eql(model.cy_name)
       end
     end
 

--- a/spec/support/shared_examples/translatable_examples.rb
+++ b/spec/support/shared_examples/translatable_examples.rb
@@ -1,0 +1,42 @@
+RSpec.shared_examples 'translatable' do
+  let(:factory) { described_class.model_name.singular.to_sym }
+  let(:model) { build(factory) }
+
+  describe '#en_name' do
+    it 'returns the value for name' do
+      expect(model.en_name).to eql(model.name)
+    end
+  end
+
+  describe '#localized_name' do
+    context 'when locale is "cy"' do
+      around do |example|
+        I18n.with_locale(:cy) { example.run }
+      end
+
+      context 'and a value for cy_name is present' do
+        it 'returns the value for cy_name' do
+          expect(model.localized_name).to eql(model.cy_name)
+        end
+      end
+
+      context 'and a value for cy_name is not present' do
+        before { model.cy_name = nil }
+
+        it 'returns the value for name' do
+          expect(model.localized_name).to eql(model.name)
+        end
+      end
+    end
+
+    context 'when locale is "en"' do
+      around do |example|
+        I18n.with_locale(:en) { example.run }
+      end
+
+      it 'returns the value for name' do
+        expect(model.localized_name).to eql(model.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stab at implementing a mixin for reference data models to support translation by way of introducing a `cy_name` attribute. Currently, this adds translatable support to the other advice method model, in anticipation of it's use for #5725.