### PR TITLE
Indexing firms and advisers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.7)
+    mas-rad_core (0.0.8)
       active_model_serializers
       geocoder
       http

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     mas-rad_core (0.0.7)
       active_model_serializers
       geocoder
+      http
       pg
       rails (~> 4.2.0)
       statsd-ruby
@@ -63,10 +64,15 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
+    form_data (0.1.0)
     geocoder (1.2.7)
     globalid (0.3.3)
       activesupport (>= 4.1.0)
     hike (1.2.3)
+    http (0.7.1)
+      form_data (~> 0.1.0)
+      http_parser.rb (~> 0.6.0)
+    http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.2)
     loofah (2.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     mas-rad_core (0.0.7)
+      active_model_serializers
       geocoder
       pg
       rails (~> 4.2.0)
@@ -29,6 +30,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    active_model_serializers (0.9.3)
+      activemodel (>= 3.2)
     activejob (4.2.0)
       activesupport (= 4.2.0)
       globalid (>= 0.3.0)

--- a/app/jobs/index_firm_job.rb
+++ b/app/jobs/index_firm_job.rb
@@ -1,4 +1,5 @@
 class IndexFirmJob < ActiveJob::Base
   def perform(firm)
+    data = FirmSerializer.new(firm)
   end
 end

--- a/app/jobs/index_firm_job.rb
+++ b/app/jobs/index_firm_job.rb
@@ -1,5 +1,5 @@
 class IndexFirmJob < ActiveJob::Base
   def perform(firm)
-    data = FirmSerializer.new(firm)
+    FirmRepository.new.store(firm)
   end
 end

--- a/app/jobs/index_firm_job.rb
+++ b/app/jobs/index_firm_job.rb
@@ -1,0 +1,4 @@
+class IndexFirmJob < ActiveJob::Base
+  def perform(firm)
+  end
+end

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -12,6 +12,8 @@ class Adviser < ActiveRecord::Base
 
   before_validation :upcase_postcode
 
+  after_save :schedule_indexing, if: -> { valid? && geocoded? }
+
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
   validates :travel_distance,
@@ -56,6 +58,10 @@ class Adviser < ActiveRecord::Base
     if valid? && postcode_changed?
       GeocodeAdviserJob.perform_later(self)
     end
+  end
+
+  def schedule_indexing
+    IndexFirmJob.perform_later(firm)
   end
 
   def upcase_postcode

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -37,6 +37,10 @@ class Adviser < ActiveRecord::Base
     "#{postcode}, United Kingdom"
   end
 
+  def geocoded?
+    latitude.present? && longitude.present?
+  end
+
   def field_order
     [
       :reference_number,

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -90,6 +90,10 @@ class Firm < ActiveRecord::Base
 
   after_save :geocode_if_needed
 
+  def postcode_searchable?
+    true
+  end
+
   def full_street_address
     [address_line_one, address_line_two, address_postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')
   end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -90,10 +90,6 @@ class Firm < ActiveRecord::Base
 
   after_save :geocode_if_needed
 
-  def postcode_searchable?
-    true
-  end
-
   def full_street_address
     [address_line_one, address_line_two, address_postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')
   end
@@ -105,6 +101,7 @@ class Firm < ActiveRecord::Base
   def in_person_advice?
     in_person_advice_methods.present?
   end
+  alias :postcode_searchable? :in_person_advice?
 
   def subsidiary?
     parent.present?

--- a/app/serializers/adviser_serializer.rb
+++ b/app/serializers/adviser_serializer.rb
@@ -1,0 +1,20 @@
+class AdviserSerializer < ActiveModel::Serializer
+  self.root = false
+
+  attributes :_id, :name, :range, :location
+
+  def _id
+    object.id
+  end
+
+  def range
+    object.travel_distance
+  end
+
+  def location
+    {
+      lat: object.latitude,
+      lon: object.longitude
+    }
+  end
+end

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -1,0 +1,15 @@
+class FirmSerializer < ActiveModel::Serializer
+  self.root = false
+
+  attributes :_id, :registered_name, :postcode_searchable
+
+  has_many :advisers
+
+  def postcode_searchable
+    object.postcode_searchable?
+  end
+
+  def _id
+    object.id
+  end
+end

--- a/lib/mas/elastic_search_client.rb
+++ b/lib/mas/elastic_search_client.rb
@@ -5,4 +5,11 @@ class ElasticSearchClient
     @index  = "rad_#{Rails.env}"
     @server = ENV.fetch('BONSAI_URL', 'http://localhost:9200')
   end
+
+  def store(path, json)
+    uri = "#{server}/#{index}/#{path}"
+    res = HTTP.put(uri, json: json)
+
+    res.status.ok?
+  end
 end

--- a/lib/mas/elastic_search_client.rb
+++ b/lib/mas/elastic_search_client.rb
@@ -11,8 +11,8 @@ class ElasticSearchClient
     res.status.ok?
   end
 
-  def search(path, json = {})
-    res = HTTP.post(uri_for(path), json: json)
+  def search(path, json = '')
+    res = HTTP.post(uri_for(path), body: json)
     SearchResult.new(res)
   end
 

--- a/lib/mas/elastic_search_client.rb
+++ b/lib/mas/elastic_search_client.rb
@@ -1,0 +1,8 @@
+class ElasticSearchClient
+  attr_reader :index, :server
+
+  def initialize
+    @index  = "rad_#{Rails.env}"
+    @server = ENV.fetch('BONSAI_URL', 'http://localhost:9200')
+  end
+end

--- a/lib/mas/elastic_search_client.rb
+++ b/lib/mas/elastic_search_client.rb
@@ -7,9 +7,18 @@ class ElasticSearchClient
   end
 
   def store(path, json)
-    uri = "#{server}/#{index}/#{path}"
-    res = HTTP.put(uri, json: json)
-
+    res = HTTP.put(uri_for(path), json: json)
     res.status.ok?
+  end
+
+  def search(path, json = {})
+    res = HTTP.post(uri_for(path), json: json)
+    SearchResult.new(res)
+  end
+
+  private
+
+  def uri_for(path)
+    "#{server}/#{index}/#{path}"
   end
 end

--- a/lib/mas/firm_repository.rb
+++ b/lib/mas/firm_repository.rb
@@ -12,4 +12,8 @@ class FirmRepository
 
     client.store(path, json)
   end
+
+  def search(query)
+    client.search('firms/_search', query.as_json)
+  end
 end

--- a/lib/mas/firm_repository.rb
+++ b/lib/mas/firm_repository.rb
@@ -1,0 +1,15 @@
+class FirmRepository
+  attr_reader :client, :serializer
+
+  def initialize(client = ElasticSearchClient, serializer = FirmSerializer)
+    @client     = client.new
+    @serializer = serializer
+  end
+
+  def store(firm)
+    json = serializer.new(firm).as_json
+    path = "#{firm.model_name.plural}/#{firm.to_param}"
+
+    client.store(path, json)
+  end
+end

--- a/lib/mas/firm_repository.rb
+++ b/lib/mas/firm_repository.rb
@@ -14,6 +14,6 @@ class FirmRepository
   end
 
   def search(query)
-    client.search('firms/_search', query.as_json)
+    client.search('firms/_search', query)
   end
 end

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -1,0 +1,14 @@
+class FirmResult
+  attr_reader :id,
+    :name,
+    :closest_adviser,
+    :total_advisers
+
+  def initialize(data)
+    source = data['_source']
+    @id    = source['_id']
+    @name  = source['registered_name']
+    @total_advisers  = source['advisers'].count
+    @closest_adviser = data['sort'].first
+  end
+end

--- a/lib/mas/rad_core/engine.rb
+++ b/lib/mas/rad_core/engine.rb
@@ -1,4 +1,5 @@
 require 'active_job'
+require 'active_model_serializers'
 require 'geocoder'
 require 'statsd'
 

--- a/lib/mas/rad_core/engine.rb
+++ b/lib/mas/rad_core/engine.rb
@@ -1,6 +1,7 @@
 require 'active_job'
 require 'active_model_serializers'
 require 'geocoder'
+require 'http'
 require 'statsd'
 
 module MAS

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.7'
+    VERSION = '0.0.8'
   end
 end

--- a/lib/mas/search_result.rb
+++ b/lib/mas/search_result.rb
@@ -1,0 +1,11 @@
+class SearchResult
+  attr_reader :raw_response
+
+  def initialize(response)
+    @raw_response = response
+  end
+
+  def firms
+    return [] unless raw_response.status.ok?
+  end
+end

--- a/lib/mas/search_result.rb
+++ b/lib/mas/search_result.rb
@@ -7,5 +7,19 @@ class SearchResult
 
   def firms
     return [] unless raw_response.status.ok?
+
+    @firms ||= hits.map { |hit| FirmResult.new(hit) }
+  end
+
+  private
+
+  def hits
+    json = JSON.parse(raw_response.body.to_s)
+
+    if json['hits'] && json['hits']['hits']
+      json['hits']['hits']
+    else
+      []
+    end
   end
 end

--- a/mas-rad_core.gemspec
+++ b/mas-rad_core.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'active_model_serializers'
   s.add_dependency 'geocoder'
+  s.add_dependency 'http'
   s.add_dependency 'pg'
   s.add_dependency 'statsd-ruby'
 

--- a/mas-rad_core.gemspec
+++ b/mas-rad_core.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '~> 4.2.0'
 
+  s.add_dependency 'active_model_serializers'
   s.add_dependency 'geocoder'
   s.add_dependency 'pg'
   s.add_dependency 'statsd-ruby'

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Force jobs to run in test mode
+  config.active_job.queue_adapter = :test
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/spec/fixtures/search_results.json
+++ b/spec/fixtures/search_results.json
@@ -1,0 +1,91 @@
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "failed": 0
+  },
+  "hits": {
+    "total": 3,
+    "max_score": null,
+    "hits": [
+    {
+      "_index": "rad_test",
+      "_type": "firms",
+      "_id": "1",
+      "_score": null,
+      "_source": {
+        "_id": 1,
+        "registered_name": "Financial Advice 1 Ltd.",
+        "postcode_searchable": true,
+        "advisers": [
+        {
+          "_id": 1,
+          "name": "Ben Lovell",
+          "range": 50,
+          "location": {
+            "lat": 51.428473,
+            "lon": -0.943616
+          }
+        }
+        ]
+      },
+      "sort": [
+        0.7794549719530739
+        ]
+    },
+    {
+      "_index": "rad_test",
+      "_type": "firms",
+      "_id": "2",
+      "_score": null,
+      "_source": {
+        "_id": 2,
+        "registered_name": "Financial Advice 2 Ltd.",
+        "postcode_searchable": true,
+        "advisers": [
+        {
+          "_id": 2,
+          "name": "Ben Lovell",
+          "range": 50,
+          "location": {
+            "lat": 52.633013,
+            "lon": -1.131257
+          }
+        }
+        ]
+      },
+      "sort": [
+        84.20095125261956
+        ]
+    },
+    {
+      "_index": "rad_test",
+      "_type": "firms",
+      "_id": "3",
+      "_score": null,
+      "_source": {
+        "_id": 3,
+        "registered_name": "Financial Advice 3 Ltd.",
+        "postcode_searchable": true,
+        "advisers": [
+        {
+          "_id": 3,
+          "name": "Ben Lovell",
+          "range": 50,
+          "location": {
+            "lat": 55.856191,
+            "lon": -4.247082
+          }
+        }
+        ]
+      },
+      "sort": [
+        334.59761250497326
+        ]
+    }
+    ]
+  }
+}
+

--- a/spec/fixtures/vcr_cassettes/search_firms.yml
+++ b/spec/fixtures/vcr_cassettes/search_firms.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:9200/rad_test/firms/_search
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:9200
+      User-Agent:
+      - RubyHTTPGem/0.7.1
+  response:
+    status:
+      code: !ruby/marshalable:HTTP::Response::Status
+        :__v2__:
+        - :@code
+        ? - 200
+        : 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '874'
+    body:
+      encoding: UTF-8
+      string: '{"took":26,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":3,"max_score":1.0,"hits":[{"_index":"rad_test","_type":"firms","_id":"1","_score":1.0,"_source":{"_id":1,"registered_name":"Financial
+        Advice 1 Ltd.","postcode_searchable":true,"advisers":[{"_id":1,"name":"Ben
+        Lovell","range":50,"location":{"lat":51.428473,"lon":-0.943616}}]}},{"_index":"rad_test","_type":"firms","_id":"2","_score":1.0,"_source":{"_id":2,"registered_name":"Financial
+        Advice 2 Ltd.","postcode_searchable":true,"advisers":[{"_id":2,"name":"Ben
+        Lovell","range":50,"location":{"lat":52.633013,"lon":-1.131257}}]}},{"_index":"rad_test","_type":"firms","_id":"3","_score":1.0,"_source":{"_id":3,"registered_name":"Financial
+        Advice 3 Ltd.","postcode_searchable":true,"advisers":[{"_id":3,"name":"Ben
+        Lovell","range":50,"location":{"lat":55.856191,"lon":-4.247082}}]}}]}}'
+    http_version: 
+  recorded_at: Wed, 25 Feb 2015 14:45:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/search_firms.yml
+++ b/spec/fixtures/vcr_cassettes/search_firms.yml
@@ -5,10 +5,8 @@ http_interactions:
     uri: http://localhost:9200/rad_test/firms/_search
     body:
       encoding: UTF-8
-      string: "{}"
+      string: ''
     headers:
-      Content-Type:
-      - application/json
       Host:
       - localhost:9200
       User-Agent:
@@ -25,10 +23,10 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '874'
+      - '873'
     body:
       encoding: UTF-8
-      string: '{"took":26,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":3,"max_score":1.0,"hits":[{"_index":"rad_test","_type":"firms","_id":"1","_score":1.0,"_source":{"_id":1,"registered_name":"Financial
+      string: '{"took":1,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":3,"max_score":1.0,"hits":[{"_index":"rad_test","_type":"firms","_id":"1","_score":1.0,"_source":{"_id":1,"registered_name":"Financial
         Advice 1 Ltd.","postcode_searchable":true,"advisers":[{"_id":1,"name":"Ben
         Lovell","range":50,"location":{"lat":51.428473,"lon":-0.943616}}]}},{"_index":"rad_test","_type":"firms","_id":"2","_score":1.0,"_source":{"_id":2,"registered_name":"Financial
         Advice 2 Ltd.","postcode_searchable":true,"advisers":[{"_id":2,"name":"Ben
@@ -36,5 +34,5 @@ http_interactions:
         Advice 3 Ltd.","postcode_searchable":true,"advisers":[{"_id":3,"name":"Ben
         Lovell","range":50,"location":{"lat":55.856191,"lon":-4.247082}}]}}]}}'
     http_version: 
-  recorded_at: Wed, 25 Feb 2015 14:45:38 GMT
+  recorded_at: Fri, 27 Feb 2015 19:45:05 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/store_firm_1.yml
+++ b/spec/fixtures/vcr_cassettes/store_firm_1.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://localhost:9200/rad_test/firms/1
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:9200
+      User-Agent:
+      - RubyHTTPGem/0.7.1
+  response:
+    status:
+      code: !ruby/marshalable:HTTP::Response::Status
+        :__v2__:
+        - :@code
+        ? - 200
+        : 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '76'
+    body:
+      encoding: UTF-8
+      string: '{"_index":"rad_test","_type":"firms","_id":"1","_version":4,"created":false}'
+    http_version: 
+  recorded_at: Mon, 23 Feb 2015 13:31:48 GMT
+recorded_with: VCR 2.9.3

--- a/spec/jobs/index_firm_job_spec.rb
+++ b/spec/jobs/index_firm_job_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe IndexFirmJob, '#perform' do
+  subject { described_class.new }
+
+  it 'indexes the firm' do
+    skip
+    adviser = create(:adviser)
+    subject.perform(adviser.firm)
+  end
+end

--- a/spec/jobs/index_firm_job_spec.rb
+++ b/spec/jobs/index_firm_job_spec.rb
@@ -1,9 +1,14 @@
 RSpec.describe IndexFirmJob, '#perform' do
-  subject { described_class.new }
+  let(:firm) { create(:adviser).firm }
+  let(:repository) { instance_double(FirmRepository) }
 
-  it 'indexes the firm' do
-    skip
-    adviser = create(:adviser)
-    subject.perform(adviser.firm)
+  before do
+    allow(FirmRepository).to receive(:new).and_return(repository)
+  end
+
+  it 'delegates to the firm repository' do
+    expect(repository).to receive(:store).with(firm)
+
+    described_class.new.perform(firm)
   end
 end

--- a/spec/lib/mas/elastic_search_client_spec.rb
+++ b/spec/lib/mas/elastic_search_client_spec.rb
@@ -32,4 +32,14 @@ RSpec.describe ElasticSearchClient do
       end
     end
   end
+
+  describe '#search' do
+    context 'when successful' do
+      it 'returns the resulting `SearchResult` object' do
+        VCR.use_cassette(:search_firms) do
+          expect(described_class.new.search('firms/_search')).to be_a(SearchResult)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/mas/elastic_search_client_spec.rb
+++ b/spec/lib/mas/elastic_search_client_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe ElasticSearchClient do
+  describe 'configuration' do
+    context 'when unconfigured' do
+      it 'defaults the index' do
+        expect(described_class.new.index).to eql('rad_test')
+      end
+
+      it 'defaults the server' do
+        expect(described_class.new.server).to eql('http://localhost:9200')
+      end
+    end
+
+    context 'when configured' do
+      before { @original_url = ENV['BONSAI_URL'] }
+
+      it 'configures server from the BONSAI_URL' do
+        ENV['BONSAI_URL'] = 'http://example.com'
+
+        expect(described_class.new.server).to eql(ENV['BONSAI_URL'])
+      end
+
+      after { ENV['BONSAI_URL'] = @original_url }
+    end
+  end
+
+  describe '#store' do
+    it 'WIP'
+  end
+end

--- a/spec/lib/mas/elastic_search_client_spec.rb
+++ b/spec/lib/mas/elastic_search_client_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe ElasticSearchClient do
   end
 
   describe '#store' do
-    it 'WIP'
+    context 'when successful' do
+      it 'returns truthily' do
+        VCR.use_cassette(:store_firm_1) do
+          expect(described_class.new.store('firms/1', {})).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/spec/lib/mas/firm_repository_spec.rb
+++ b/spec/lib/mas/firm_repository_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe FirmRepository do
       it 'delegates to the configured client' do
         expect(client).to receive(:search).with(/.*/, {})
 
-        described_class.new(client_class).search(double(as_json: {}))
+        described_class.new(client_class).search({})
       end
     end
   end

--- a/spec/lib/mas/firm_repository_spec.rb
+++ b/spec/lib/mas/firm_repository_spec.rb
@@ -11,16 +11,26 @@ RSpec.describe FirmRepository do
     end
   end
 
-  describe '#store' do
-    let(:firm) { create(:firm) }
+  describe 'searching and retrieving' do
     let(:client) { double }
+    let(:client_class) { double(new: client) }
 
-    before { FakeClient = double(new: client) }
+    describe '#store' do
+      let(:firm) { create(:firm) }
 
-    it 'delegates to the configured client' do
-      expect(client).to receive(:store).with(/firms\/\d+/, hash_including(:_id))
+      it 'delegates to the configured client' do
+        expect(client).to receive(:store).with(/firms\/\d+/, hash_including(:_id))
 
-      described_class.new(FakeClient).store(firm)
+        described_class.new(client_class).store(firm)
+      end
+    end
+
+    describe '#search' do
+      it 'delegates to the configured client' do
+        expect(client).to receive(:search).with(/.*/, {})
+
+        described_class.new(client_class).search(double(as_json: {}))
+      end
     end
   end
 end

--- a/spec/lib/mas/firm_repository_spec.rb
+++ b/spec/lib/mas/firm_repository_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe FirmRepository do
+  describe 'initialization' do
+    subject { described_class.new }
+
+    it 'defaults `client`' do
+      expect(subject.client).to be_a(ElasticSearchClient)
+    end
+
+    it 'defaults `serializer`' do
+      expect(subject.serializer).to eql(FirmSerializer)
+    end
+  end
+
+  describe '#store' do
+    let(:firm) { create(:firm) }
+    let(:client) { double }
+
+    before { FakeClient = double(new: client) }
+
+    it 'delegates to the configured client' do
+      expect(client).to receive(:store).with(/firms\/\d+/, hash_including(:_id))
+
+      described_class.new(FakeClient).store(firm)
+    end
+  end
+end

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe FirmResult do
+  let(:data) do
+    {
+      '_index'  => 'rad_test',
+      '_type'   => 'firms',
+      '_id'     => '1',
+      '_score'  => nil,
+      '_source' => {
+        '_id' => 1,
+        'registered_name' => 'Financial Advice 1 Ltd.',
+        'postcode_searchable' => true,
+        'advisers' => [
+          {
+            '_id'      => 1,
+            'name'     => 'Ben Lovell',
+            'range'    => 50,
+            'location' => { 'lat' => 51.428473, 'lon' => -0.943616 }
+          }
+        ]
+      },
+      'sort' => [0.7794549719530739]
+    }
+  end
+
+  subject { described_class.new(data) }
+
+  describe 'the deserialized result' do
+    it 'maps the `id`' do
+      expect(subject.id).to eq(1)
+    end
+
+    it 'maps the `name`' do
+      expect(subject.name).to eq('Financial Advice 1 Ltd.')
+    end
+
+    it 'maps the `closest_adviser`' do
+      expect(subject.closest_adviser).to eq(0.7794549719530739)
+    end
+
+    it 'maps the `total_advisers`' do
+      expect(subject.total_advisers).to eq(1)
+    end
+  end
+end

--- a/spec/lib/mas/search_result_spec.rb
+++ b/spec/lib/mas/search_result_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SearchResult do
   end
 
   describe '#firms' do
-
     context 'when the response is not `ok?`' do
       let(:response) { double(status: double(ok?: false)) }
 
@@ -16,8 +15,15 @@ RSpec.describe SearchResult do
     end
 
     context 'when the response is `ok?`' do
+      let(:response) { double(status: double(ok?: true), body: body) }
+
       context 'with results' do
-        it 'is pending'
+        let(:json) { IO.read(Rails.root.join('..', 'fixtures', 'search_results.json')) }
+        let(:body) { double(to_s: json) }
+
+        it 'returns 3 deserialized results' do
+          expect(described_class.new(response).firms.length).to eq(3)
+        end
       end
     end
   end

--- a/spec/lib/mas/search_result_spec.rb
+++ b/spec/lib/mas/search_result_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe SearchResult do
+  describe 'initialization' do
+    it 'is configured with the response' do
+      expect(described_class.new(:hi).raw_response).to eq(:hi)
+    end
+  end
+
+  describe '#firms' do
+
+    context 'when the response is not `ok?`' do
+      let(:response) { double(status: double(ok?: false)) }
+
+      it 'returns []' do
+        expect(described_class.new(response).firms).to be_empty
+      end
+    end
+
+    context 'when the response is `ok?`' do
+      context 'with results' do
+        it 'is pending'
+      end
+    end
+  end
+end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -1,4 +1,18 @@
 RSpec.describe Adviser do
+  describe '#geocoded?' do
+    context 'when the adviser has lat/long' do
+      it 'is classed as geocoded' do
+        expect(build(:adviser)).to be_geocoded
+      end
+    end
+
+    context 'when the adviser does not have lat/long' do
+      it 'is not classed as geocoded' do
+        expect(build(:adviser, latitude: nil, longitude: nil)).to_not be_geocoded
+      end
+    end
+  end
+
   describe 'before validation' do
     context 'when a reference number is present' do
       let(:attributes) { attributes_for(:adviser) }

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe Adviser do
     end
   end
 
+  describe 'scheduling the parent firm for indexing' do
+    context 'when the adviser has not been geocoded' do
+      it 'does not schedule the job' do
+        expect do
+          create(:adviser, latitude: nil, longitude: nil)
+        end.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }
+      end
+    end
+
+    context 'when the adviser has been geocoded' do
+      it 'schedules the job' do
+        expect do
+          create(:adviser)
+        end.to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(1)
+      end
+    end
+  end
+
   describe 'before validation' do
     context 'when a reference number is present' do
       let(:attributes) { attributes_for(:adviser) }

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -4,11 +4,8 @@ RSpec.describe Firm do
   before { allow(GeocodeFirmJob).to receive(:perform_later) }
 
   describe '#postcode_searchable?' do
-    context 'when an in person method has been specified' do
-      it 'is true' do
-        expect(firm).to be_postcode_searchable
-        skip 'default this to true for now until I can clarify'
-      end
+    it 'delegates to #in_person_advice?' do
+      expect(firm).to be_postcode_searchable
     end
   end
 

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -3,6 +3,15 @@ RSpec.describe Firm do
 
   before { allow(GeocodeFirmJob).to receive(:perform_later) }
 
+  describe '#postcode_searchable?' do
+    context 'when an in person method has been specified' do
+      it 'is true' do
+        expect(firm).to be_postcode_searchable
+        skip 'default this to true for now until I can clarify'
+      end
+    end
+  end
+
   describe '#in_person_advice?' do
     context 'when the firm offers in person advice' do
       it 'is true' do

--- a/spec/serializers/adviser_serializer_spec.rb
+++ b/spec/serializers/adviser_serializer_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe AdviserSerializer do
+  let(:adviser) { create(:adviser) }
+
+  describe 'the serialized json' do
+    subject { described_class.new(adviser).as_json }
+
+    it 'exposes `_id`' do
+      expect(subject[:_id]).to eql(adviser.id)
+    end
+
+    it 'exposes `name`' do
+      expect(subject[:name]).to eql(adviser.name)
+    end
+
+    it 'exposes `range`' do
+      expect(subject[:range]).to eql(adviser.travel_distance)
+    end
+
+    it 'exposes `location`' do
+      expect(subject[:location][:lat]).to eql(adviser.latitude)
+      expect(subject[:location][:lon]).to eql(adviser.longitude)
+    end
+  end
+end

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe FirmSerializer do
+  let(:firm) { create(:adviser).firm }
+
+  describe 'the serialized json' do
+    subject { described_class.new(firm).as_json }
+
+    it 'exposes `_id`' do
+      expect(subject[:_id]).to eql(firm.id)
+    end
+
+    it 'exposes `registered_name`' do
+      expect(subject[:registered_name]).to eql(firm.registered_name)
+    end
+
+    it 'exposes `postcode_searchable`' do
+      expect(subject[:postcode_searchable]).to eql(firm.postcode_searchable?)
+    end
+
+    it 'exposes the `advisers` association' do
+      expect(subject[:advisers]).to be
+    end
+  end
+end


### PR DESCRIPTION
Provides a basis for indexing `Firm`s and their associated `Adviser`s.

Some caveats and areas for attention later:

* Robustness around ES communication
* Robustness around indexing
* There may be some timing issues around `Adviser` being geocoded before being indexed

These points will be addressed, but this is good to get some eyes on for now.