### PR TITLE
HTTP Authentication

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.8)
+    mas-rad_core (0.0.9)
       active_model_serializers
       geocoder
       http
@@ -64,7 +64,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.4.3)
       i18n (~> 0.5)
-    form_data (0.1.0)
+    form_data (0.1.2)
+      http-form_data
     geocoder (1.2.7)
     globalid (0.3.3)
       activesupport (>= 4.1.0)
@@ -72,6 +73,7 @@ GEM
     http (0.7.1)
       form_data (~> 0.1.0)
       http_parser.rb (~> 0.6.0)
+    http-form_data (1.0.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.2)

--- a/lib/mas/elastic_search_client.rb
+++ b/lib/mas/elastic_search_client.rb
@@ -7,16 +7,32 @@ class ElasticSearchClient
   end
 
   def store(path, json)
-    res = HTTP.put(uri_for(path), json: json)
+    res = http.put(uri_for(path), json: json)
     res.status.ok?
   end
 
   def search(path, json = '')
-    res = HTTP.post(uri_for(path), body: json)
+    res = http.post(uri_for(path), body: json)
     SearchResult.new(res)
   end
 
   private
+
+  def http
+    authenticate? ? HTTP.basic_auth(user: username, pass: password) : HTTP
+  end
+
+  def authenticate?
+    username && password
+  end
+
+  def username
+    ENV['BONSAI_USERNAME']
+  end
+
+  def password
+    ENV['BONSAI_PASSWORD']
+  end
 
   def uri_for(path)
     "#{server}/#{index}/#{path}"

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.8'
+    VERSION = '0.0.9'
   end
 end


### PR DESCRIPTION
`http` gem doesn't seem to like basic authentication when passing the tokens in the URL. This works around that issue by splitting them out into specific environment variables and using `http` gem's preferred mechanism for basic auth.