### PR TITLE
5723 Types Of Advice Search

### DIFF
--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -1,12 +1,34 @@
 class FirmSerializer < ActiveModel::Serializer
   self.root = false
 
-  attributes :_id, :registered_name, :postcode_searchable
+  attributes :_id,
+    :registered_name,
+    :postcode_searchable,
+    :options_when_paying_for_care,
+    :equity_release,
+    :inheritance_tax_planning,
+    :wills_and_probate
 
   has_many :advisers
 
   def postcode_searchable
     object.postcode_searchable?
+  end
+
+  def options_when_paying_for_care
+    object.long_term_care_percent.to_i > 0
+  end
+
+  def equity_release
+    object.equity_release_percent.to_i > 0
+  end
+
+  def inheritance_tax_planning
+    object.inheritance_tax_and_estate_planning_percent.to_i > 0
+  end
+
+  def wills_and_probate
+    object.wills_and_probate_percent.to_i > 0
   end
 
   def _id

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -36,5 +36,15 @@ FactoryGirl.define do
     factory :subsidiary do
       parent factory: Firm
     end
+
+    factory :firm_with_no_business_split do
+      retirement_income_products_percent 0
+      pension_transfer_percent 0
+      long_term_care_percent 0
+      equity_release_percent 0
+      inheritance_tax_and_estate_planning_percent 0
+      wills_and_probate_percent 0
+      other_percent 0
+    end
   end
 end

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -19,5 +19,21 @@ RSpec.describe FirmSerializer do
     it 'exposes the `advisers` association' do
       expect(subject[:advisers]).to be
     end
+
+    it 'exposes `options_when_paying_for_care`' do
+      expect(subject[:options_when_paying_for_care]).to be
+    end
+
+    it 'exposes `equity_release`' do
+      expect(subject[:equity_release]).to be
+    end
+
+    it 'exposes `inheritance_tax_planning`' do
+      expect(subject[:inheritance_tax_planning]).to be
+    end
+
+    it 'exposes `wills_and_probate`' do
+      expect(subject[:wills_and_probate]).to be
+    end
   end
 end


### PR DESCRIPTION
Serializes a select few of the business split attributes to be indexed and used for the types of advice filter for consumer search,