### PR TITLE
Expose other advice methods in FirmSerializer

### DIFF
--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -7,7 +7,8 @@ class FirmSerializer < ActiveModel::Serializer
     :options_when_paying_for_care,
     :equity_release,
     :inheritance_tax_planning,
-    :wills_and_probate
+    :wills_and_probate,
+    :other_advice_methods
 
   has_many :advisers
 
@@ -33,5 +34,9 @@ class FirmSerializer < ActiveModel::Serializer
 
   def _id
     object.id
+  end
+
+  def other_advice_methods
+    object.other_advice_method_ids
   end
 end

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -35,5 +35,10 @@ RSpec.describe FirmSerializer do
     it 'exposes `wills_and_probate`' do
       expect(subject[:wills_and_probate]).to be
     end
+
+    it 'exposes names of `other_advice_methods`' do
+      expect(subject[:other_advice_methods]).
+        to eql(firm.other_advice_method_ids)
+    end
   end
 end


### PR DESCRIPTION
* expose names of other advice methods in FirmSearch to allow elastic search index on them

part of #5725