### PR TITLE
Schedule indexing after geocoding successfully

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.12)
+    mas-rad_core (0.0.13)
       active_model_serializers
       geocoder
       http

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -12,8 +12,6 @@ class Adviser < ActiveRecord::Base
 
   before_validation :upcase_postcode
 
-  after_save :schedule_indexing, if: -> { valid? && geocoded? }
-
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
   validates :travel_distance,
@@ -40,7 +38,11 @@ class Adviser < ActiveRecord::Base
   end
 
   def geocoded?
-    latitude.present? && longitude.present?
+    coordinates.compact.present?
+  end
+
+  def coordinates
+    [latitude, longitude]
   end
 
   def field_order
@@ -58,10 +60,6 @@ class Adviser < ActiveRecord::Base
     if valid? && postcode_changed?
       GeocodeAdviserJob.perform_later(self)
     end
-  end
-
-  def schedule_indexing
-    IndexFirmJob.perform_later(firm)
   end
 
   def upcase_postcode

--- a/app/models/geocodable.rb
+++ b/app/models/geocodable.rb
@@ -1,4 +1,8 @@
 module Geocodable
+  def self.included(model)
+    model.scope :geocoded, -> { model.where.not(latitude: nil, longitude: nil) }
+  end
+
   def latitude=(value)
     value = value.to_f.round(6) unless value.nil?
     write_attribute(:latitude, value)

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -12,6 +12,10 @@ class FirmSerializer < ActiveModel::Serializer
 
   has_many :advisers
 
+  def advisers
+    object.advisers.geocoded
+  end
+
   def postcode_searchable
     object.postcode_searchable?
   end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.12'
+    VERSION = '0.0.13'
   end
 end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -13,24 +13,6 @@ RSpec.describe Adviser do
     end
   end
 
-  describe 'scheduling the parent firm for indexing' do
-    context 'when the adviser has not been geocoded' do
-      it 'does not schedule the job' do
-        expect do
-          create(:adviser, latitude: nil, longitude: nil)
-        end.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }
-      end
-    end
-
-    context 'when the adviser has been geocoded' do
-      it 'schedules the job' do
-        expect do
-          create(:adviser)
-        end.to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by(1)
-      end
-    end
-  end
-
   describe 'before validation' do
     context 'when a reference number is present' do
       let(:attributes) { attributes_for(:adviser) }

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -16,10 +16,6 @@ RSpec.describe FirmSerializer do
       expect(subject[:postcode_searchable]).to eql(firm.postcode_searchable?)
     end
 
-    it 'exposes the `advisers` association' do
-      expect(subject[:advisers]).to be
-    end
-
     it 'exposes `options_when_paying_for_care`' do
       expect(subject[:options_when_paying_for_care]).to be
     end
@@ -39,6 +35,14 @@ RSpec.describe FirmSerializer do
     it 'exposes names of `other_advice_methods`' do
       expect(subject[:other_advice_methods]).
         to eql(firm.other_advice_method_ids)
+    end
+
+    describe 'advisers' do
+      before { create(:adviser, firm: firm, latitude: nil, longitude: nil) }
+
+      it 'only includes geocoded records' do
+        expect(subject[:advisers].count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
Also limit serialized advisers to geocoded ones only.