### PR TITLE
Take ordering into account

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.16)
+    mas-rad_core (0.0.17)
       active_model_serializers
       geocoder
       http

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -9,6 +9,6 @@ class FirmResult
     @id    = source['_id']
     @name  = source['registered_name']
     @total_advisers  = source['advisers'].count
-    @closest_adviser = data['sort'].first
+    @closest_adviser = data['sort'].last
   end
 end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.16'
+    VERSION = '0.0.17'
   end
 end

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -33,12 +33,20 @@ RSpec.describe FirmResult do
       expect(subject.name).to eq('Financial Advice 1 Ltd.')
     end
 
+    it 'maps the `total_advisers`' do
+      expect(subject.total_advisers).to eq(1)
+    end
+
     it 'maps the `closest_adviser`' do
       expect(subject.closest_adviser).to eq(0.7794549719530739)
     end
 
-    it 'maps the `total_advisers`' do
-      expect(subject.total_advisers).to eq(1)
+    context 'when sorted by types of advice first' do
+      before { data['sort'].unshift(123) }
+
+      it 'maps the `closest_adviser`' do
+        expect(subject.closest_adviser).to eq(0.7794549719530739)
+      end
     end
   end
 end


### PR DESCRIPTION
When multiple sort filters are applied, the order of the returned sort
values becomes positional. In which case we should always return the
last entry as we will always sort by geographical distance last.

This is somewhat fragile at the moment, so we'll revisit if we apply
more sort filters.