### PR TITLE
Restrict `Principal#firm` to parent only

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.33)
+    mas-rad_core (0.0.34)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -4,7 +4,10 @@ class Principal < ActiveRecord::Base
   before_create :generate_token
   after_create  :associate_firm
 
-  has_one :firm, primary_key: :fca_number, foreign_key: :fca_number
+  has_one :firm,
+    -> { where(parent_id: nil) },
+    primary_key: :fca_number,
+    foreign_key: :fca_number
 
   validates :fca_number,
     presence: true,

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.33'
+    VERSION = '0.0.34'
   end
 end

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -1,6 +1,14 @@
 RSpec.describe Principal do
   let(:principal) { create(:principal) }
 
+  describe '#firm' do
+    it 'is restricted to the parent firm' do
+      subsidiary = create(:firm, parent: principal.firm, fca_number: principal.fca_number)
+
+      expect(principal.firm).to_not eq(subsidiary)
+    end
+  end
+
   describe '#lookup_firm' do
     it 'returns my associated lookup firm' do
       expect(principal.lookup_firm).to be


### PR DESCRIPTION
Ensures this association is scoped to parent firms, and not subsidiaries.