### PR TITLE
Eliminate ActiveJob race

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.36)
+    mas-rad_core (0.0.37)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -31,7 +31,7 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
-  after_save :geocode_if_needed
+  after_commit :geocode, if: :geocode?
 
   def full_street_address
     "#{postcode}, United Kingdom"
@@ -48,10 +48,12 @@ class Adviser < ActiveRecord::Base
 
   private
 
-  def geocode_if_needed
-    if valid? && postcode_changed?
-      GeocodeAdviserJob.perform_later(self)
-    end
+  def geocode?
+    valid? && postcode_changed?
+  end
+
+  def geocode
+    GeocodeAdviserJob.perform_later(self)
   end
 
   def upcase_postcode

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -87,7 +87,7 @@ class Firm < ActiveRecord::Base
   validates :investment_sizes,
     length: { minimum: 1 }
 
-  after_save :geocode, if: :valid?
+  after_commit :geocode, if: :valid?
 
   def full_street_address
     [address_line_one, address_line_two, address_postcode, 'United Kingdom'].delete_if(&:blank?).join(', ')

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.36'
+    VERSION = '0.0.37'
   end
 end

--- a/spec/factories/adviser.rb
+++ b/spec/factories/adviser.rb
@@ -11,8 +11,8 @@ FactoryGirl.define do
     confirmed_disclaimer true
     firm
 
-    before(:create) { |a| a.class.skip_callback(:save, :after, :geocode_if_needed) }
-    after(:create) { |a| a.class.set_callback(:save, :after, :geocode_if_needed) }
+    before(:create) { |a| a.class.skip_callback(:save, :after, :geocode) }
+    after(:create) { |a| a.class.set_callback(:save, :after, :geocode, if: :geocode?) }
 
     after(:build) do |a|
       if a.reference_number?


### PR DESCRIPTION
The jobs were being scheduled on save, and often the referred to instance would
not yet be committed to the database, thus causing a subtle race on retrieval.

By scheduling the jobs on `after_commit` we can eliminate the issue.