### PR TITLE
Fix intermittent test failure in adviser_spec

### DIFF
--- a/spec/factories/adviser.rb
+++ b/spec/factories/adviser.rb
@@ -15,9 +15,6 @@ FactoryGirl.define do
     confirmed_disclaimer true
     firm
 
-    before(:create) { |a| a.class.skip_callback(:save, :after, :geocode) }
-    after(:create) { |a| a.class.set_callback(:save, :after, :geocode, if: :valid?) }
-
     after(:build) do |a, evaluator|
       if a.reference_number? && evaluator.create_linked_lookup_advisor
         Lookup::Adviser.create!(

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -122,11 +122,11 @@ RSpec.describe Adviser do
   end
 
   describe 'after commit' do
-    let(:adviser) { build(:adviser) }
+    let(:adviser) { create(:adviser) }
 
     context 'when the postcode is present' do
       it 'the adviser is scheduled for geocoding' do
-        expect { adviser.save! }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
+        expect { adviser.run_callbacks(:commit) }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
       end
     end
 
@@ -134,7 +134,7 @@ RSpec.describe Adviser do
       before { adviser.postcode = 'not-valid' }
 
       it 'the adviser is not scheduled for geocoding' do
-        expect { adviser.save!(validate: false) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
+        expect { adviser.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
       end
     end
   end


### PR DESCRIPTION
`after_commit` hooks are not triggered while testing. FactoryGirl
callbacks were being used to trigger the `geocode` method from
`after_save` instead, but these are only triggered when using
FactoryGirl's `create` call and NOT `build`.

The tests in the 'after commit' block were using FactoryGirl's `build`
method and so when run in isolation (or before other tests in the file)
they did not trigger the callbacks in the factory. Here's a fixed run of
the tests that consistently recreates the failure.

  rspec spec/models/adviser_spec.rb:124 --order random:26438 -f d

The fix we've implemented takes out the callbacks in the factory and
explicitly triggers the `after_commit` callback instead.