### PR TITLE
Handle destruction of an adviser

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -31,7 +31,7 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
-  after_commit :geocode, if: :valid?
+  after_commit :geocode
 
   def full_street_address
     "#{postcode}, United Kingdom"
@@ -49,7 +49,11 @@ class Adviser < ActiveRecord::Base
   private
 
   def geocode
-    GeocodeAdviserJob.perform_later(self)
+    if destroyed?
+      firm.geocode
+    elsif valid?
+      GeocodeAdviserJob.perform_later(self)
+    end
   end
 
   def upcase_postcode

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -130,11 +130,11 @@ class Firm < ActiveRecord::Base
     ]
   end
 
-  private
-
   def geocode
     GeocodeFirmJob.perform_later(self)
   end
+
+  private
 
   def upcase_postcode
     address_postcode.upcase! if address_postcode.present?


### PR DESCRIPTION
* Prevents an adviser geocoding job being scheduled
* Re-indexes the containing firm
* Change forces Firm#geocode to become public

@neoeno @benlovell