### PR TITLE
Move advisers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.49)
+    mas-rad_core (0.0.50)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -37,6 +37,14 @@ class Adviser < ActiveRecord::Base
   after_commit :geocode
   after_commit :reindex_old_firm
 
+  def self.move_all_to_firm(receiving_firm)
+    transaction do
+      current_scope.each do |adviser|
+        adviser.update!(firm: receiving_firm)
+      end
+    end
+  end
+
   def full_street_address
     "#{postcode}, United Kingdom"
   end

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -1,6 +1,8 @@
 class Adviser < ActiveRecord::Base
   include Geocodable
 
+  attr_reader :old_firm_id
+
   belongs_to :firm
 
   has_and_belongs_to_many :qualifications
@@ -31,7 +33,9 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
+  after_save :flag_changes_for_after_commit
   after_commit :geocode
+  after_commit :reindex_old_firm
 
   def full_street_address
     "#{postcode}, United Kingdom"
@@ -48,12 +52,23 @@ class Adviser < ActiveRecord::Base
 
   private
 
+  # All record of what changed is gone by the time we get to the after_commit
+  # hooks, so we need to store any important changes here to be actioned later.
+  def flag_changes_for_after_commit
+    @old_firm_id = firm_id_change.first if firm_id_changed?
+  end
+
   def geocode
     if destroyed?
       firm.geocode
     elsif valid?
       GeocodeAdviserJob.perform_later(self)
     end
+  end
+
+  def reindex_old_firm
+    IndexFirmJob.perform_later(@old_firm_id) if @old_firm_id.present?
+    @old_firm_id = nil
   end
 
   def upcase_postcode

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.49'
+    VERSION = '0.0.50'
   end
 end

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -44,11 +44,11 @@ FactoryGirl.define do
     end
 
     factory :firm_with_advisers do
-      advisers { create_list(:adviser, rand(1..3)) }
+      advisers { create_list(:adviser, 3) }
     end
 
     factory :firm_with_subsidiaries do
-      subsidiaries { create_list(:subsidiary, rand(1..3)) }
+      subsidiaries { create_list(:subsidiary, 3) }
     end
 
     factory :firm_with_principal do

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -208,4 +208,49 @@ RSpec.describe Adviser do
       end
     end
   end
+
+  describe '.move_all_to_firm' do
+    let(:original_firm) { create(:firm_with_advisers) }
+    let(:receiving_firm) { create(:firm_with_advisers) }
+
+    it 'moves a batch of advisers to another firm' do
+      advisers_to_move = original_firm.advisers.limit(2)
+      advisers_to_move.move_all_to_firm(receiving_firm)
+
+      expect(advisers_to_move[0].firm).to be(receiving_firm)
+      expect(advisers_to_move[1].firm).to be(receiving_firm)
+
+      receiving_firm.reload
+      original_firm.reload
+
+      expect(original_firm.advisers.count).to be(1)
+      expect(receiving_firm.advisers.count).to be(5)
+      expect(receiving_firm.adviser_ids).to include(advisers_to_move[0].id,
+                                                    advisers_to_move[1].id)
+      expect(original_firm.adviser_ids).not_to include(advisers_to_move[0].id,
+                                                       advisers_to_move[1].id)
+    end
+
+    context 'when one of the move operations fails' do
+      let(:advisers_to_move) { original_firm.advisers.limit(3) }
+      let(:invalid_record_index) { 1 }
+
+      before do
+        advisers_to_move[invalid_record_index].reference_number = 'NOT_VALID'
+        advisers_to_move[invalid_record_index].save!(validate: false)
+      end
+
+      it 'aborts the entire operation' do
+        expect(advisers_to_move[invalid_record_index]).not_to be_valid
+        expect { advisers_to_move.move_all_to_firm(receiving_firm) }
+          .to raise_error(ActiveRecord::RecordInvalid)
+
+        receiving_firm.reload
+        original_firm.reload
+
+        expect(original_firm.advisers.count).to be(3)
+        expect(receiving_firm.advisers.count).to be(3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implement moving single or batches of advisers between firms.

Ensures all records get re-indexed in ES.

Example client code:

```ruby
# Find the advisers you want to move, in this case restricting just to advisers in the one firm
from_firm = Firm.find_by(fca_number: ....)
ref_nums = ['GBP00003', 'RMP01116']
advisers_to_move = from_firm.advisers.where(reference_number: ref_nums)

# Validation for this scenario, e.g.
fail 'not all advisers are in the same firm' if ref_nums.size != advisers_to_move.count

# Move the advisers. `move_all_to_firm` operates only on the `advisers_to_move` result set
receiving_firm = Firm.find_by(fca_number: ....)
advisers_to_move.move_all_to_firm(receiving_firm)
```
