### PR TITLE
IndexFirmJob needs to be passed the firm not just an ID

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -75,7 +75,7 @@ class Adviser < ActiveRecord::Base
   end
 
   def reindex_old_firm
-    IndexFirmJob.perform_later(@old_firm_id) if @old_firm_id.present?
+    IndexFirmJob.perform_later(Firm.find(@old_firm_id)) if @old_firm_id.present?
     @old_firm_id = nil
   end
 

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Adviser do
       end
 
       it 'triggers reindexing of the original firm (once)' do
-        expect(IndexFirmJob).to receive(:perform_later).once().with(original_firm.id)
+        expect(IndexFirmJob).to receive(:perform_later).once().with(original_firm)
         subject.firm = receiving_firm
         save_with_commit_callback(subject)
 


### PR DESCRIPTION
Was passing the wrong type! Gave it an numeric id but it needed a firm object. It told me about the problem by raising an error in the firm_serializer. Doh.

`<sssshhhh>`Oh for the days of parameter type checking`</sssshhhh>`