### PR TITLE
Cascade from principal

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -21,7 +21,7 @@ class Firm < ActiveRecord::Base
   has_and_belongs_to_many :investment_sizes
 
   belongs_to :initial_meeting_duration
-  belongs_to :principal, primary_key: :fca_number, foreign_key: :fca_number, dependent: :destroy
+  belongs_to :principal, primary_key: :fca_number, foreign_key: :fca_number
   belongs_to :parent, class_name: 'Firm'
 
   has_many :advisers, dependent: :destroy

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -7,7 +7,8 @@ class Principal < ActiveRecord::Base
   has_one :firm,
     -> { where(parent_id: nil) },
     primary_key: :fca_number,
-    foreign_key: :fca_number
+    foreign_key: :fca_number,
+    dependent: :destroy
 
   validates :fca_number,
     presence: true,

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -297,11 +297,11 @@ RSpec.describe Firm do
     context 'when the firm has a principal' do
       let(:firm) { create(:firm_with_principal) }
 
-      it 'cascades destroy to principal' do
+      it 'does not destroy the principal' do
         principal = firm.principal
         firm.destroy
         firm.run_callbacks(:commit)
-        expect(Principal.where(token: principal.id)).to be_empty
+        expect(Principal.where(token: principal.id)).not_to be_empty
       end
     end
 

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -204,4 +204,12 @@ RSpec.describe Principal do
       expect(principal.field_order).to contain_exactly(*fields)
     end
   end
+
+  describe '#destroy' do
+    it 'cascades to the firm' do
+      firm = principal.firm
+      principal.destroy
+      expect(Firm.where(id: firm.id)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Changes firm->principal association so that destroying a firm no longer destroys the associated principal. The principal may be linked to other firms and we should not leave them orphaned.

Also changes `Principal` so that associated firms are destroyed when destroying their principal. As the principal is the entity which ties everything together, it doesn't make sense to retain any firms linked to them.

@neoeno wdyt?