### PR TITLE
Refactor/gradual rename subs to trading names

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -26,6 +26,7 @@ class Firm < ActiveRecord::Base
 
   has_many :advisers, dependent: :destroy
   has_many :subsidiaries, class_name: 'Firm', foreign_key: :parent_id, dependent: :destroy
+  has_many :trading_names, class_name: 'Firm', foreign_key: :parent_id, dependent: :destroy
   has_many :qualifications, -> { reorder('').uniq }, through: :advisers
   has_many :accreditations, -> { reorder('').uniq }, through: :advisers
 

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -105,9 +105,11 @@ class Firm < ActiveRecord::Base
   end
   alias :postcode_searchable? :in_person_advice?
 
-  def subsidiary?
+  def trading_name?
     parent.present?
   end
+
+  alias_method :subsidiary?, :trading_name?
 
   def field_order
     [

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -30,8 +30,10 @@ FactoryGirl.define do
     latitude { Faker::Address.latitude.to_f.round(6) }
     longitude { Faker::Address.longitude.to_f.round(6) }
 
-    factory :subsidiary do
+    factory :trading_name do
       parent factory: Firm
+
+      factory :subsidiary
     end
 
     factory :firm_with_no_business_split do
@@ -48,8 +50,10 @@ FactoryGirl.define do
       advisers { create_list(:adviser, 3) }
     end
 
-    factory :firm_with_subsidiaries do
-      subsidiaries { create_list(:subsidiary, 3, fca_number: fca_number) }
+    factory :firm_with_trading_names do
+      subsidiaries { create_list(:trading_name, 3, fca_number: fca_number) }
+
+      factory :firm_with_subsidiaries
     end
 
     factory :firm_with_principal do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Firm do
     end
 
     context 'when the firm has subsidiaries' do
-      let(:firm) { create(:firm_with_subsidiaries) }
+      let(:firm) { create(:firm_with_trading_names) }
 
       it 'cascades destroy to subsidiaries' do
         subsidiary = firm.subsidiaries.first


### PR DESCRIPTION
The terminology in the domain model is a bit mixed at the moment. A firm can have one or more "trading names", however in our current schema they are referred to as subsidiaries which is a different thing in the real world.

This PR begins a process of migrating the model to use the same language as we are using in the view, by simply aliasing several key bits so that client code in `rad` looks less confusing.