### PR TITLE
[DEV APPROVED] Rename `Adviser.most_recently_edited` -> Adviser.most_recently_updated

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -37,7 +37,7 @@ class Adviser < ActiveRecord::Base
   after_commit :geocode
   after_commit :reindex_old_firm
 
-  scope :most_recently_edited, -> (limit: 3) { order(updated_at: 'DESC').limit(limit) }
+  scope :most_recently_updated, -> (limit: 3) { order(updated_at: 'DESC').limit(limit) }
 
   def self.on_firms_with_fca_number(fca_number)
     firms = Firm.where(fca_number: fca_number)

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -254,14 +254,14 @@ RSpec.describe Adviser do
     end
   end
 
-  describe '#most_recently_edited' do
+  describe '#most_recently_updated' do
     it 'returns an empty list when there are no advisers' do
-      expect(Adviser.most_recently_edited).to eq([])
+      expect(Adviser.most_recently_updated).to eq([])
     end
 
     it 'returns one adviser when there is one adviser' do
       adviser = FactoryGirl.create(:adviser)
-      most_recent = Adviser.most_recently_edited
+      most_recent = Adviser.most_recently_updated
 
       expect(most_recent.length).to eq(1)
       expect(most_recent[0]).to eq(adviser)
@@ -269,7 +269,7 @@ RSpec.describe Adviser do
 
     it 'provides three advisers when there are four advisers' do
       FactoryGirl.create_list(:adviser, 4)
-      most_recent = Adviser.most_recently_edited
+      most_recent = Adviser.most_recently_updated
 
       expect(most_recent.length).to eq(3)
     end
@@ -280,7 +280,7 @@ RSpec.describe Adviser do
       fourth_adviser = FactoryGirl.create(:adviser, updated_at: 3.weeks.ago)
       FactoryGirl.create(:adviser, updated_at: 4.weeks.ago)
 
-      most_recent = Adviser.most_recently_edited
+      most_recent = Adviser.most_recently_updated
 
       expect(most_recent[0]).to eq(second_adviser)
       expect(most_recent[1]).to eq(first_adviser)


### PR DESCRIPTION
`_updated` is a better name, as it orders by `updated_at`