### PR TITLE
Strip out recently used scopes

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -37,8 +37,6 @@ class Adviser < ActiveRecord::Base
   after_commit :geocode
   after_commit :reindex_old_firm
 
-  scope :most_recently_edited, -> (limit: 3) { order(updated_at: 'DESC').limit(limit) }
-
   def self.on_firms_with_fca_number(fca_number)
     firms = Firm.where(fca_number: fca_number)
     where(firm: firms)

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -14,10 +14,6 @@ class Firm < ActiveRecord::Base
   scope :registered, -> { where.not(email_address: nil) }
   scope :sorted_by_registered_name, -> { order(:registered_name) }
 
-  def self.most_recently_updated(limit: nil)
-    order(updated_at: :desc).limit(limit)
-  end
-
   has_and_belongs_to_many :in_person_advice_methods
   has_and_belongs_to_many :other_advice_methods
   has_and_belongs_to_many :initial_advice_fee_structures

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -254,40 +254,6 @@ RSpec.describe Adviser do
     end
   end
 
-  describe '#most_recently_edited' do
-    it 'returns an empty list when there are no advisers' do
-      expect(Adviser.most_recently_edited).to eq([])
-    end
-
-    it 'returns one adviser when there is one adviser' do
-      adviser = FactoryGirl.create(:adviser)
-      most_recent = Adviser.most_recently_edited
-
-      expect(most_recent.length).to eq(1)
-      expect(most_recent[0]).to eq(adviser)
-    end
-
-    it 'provides three advisers when there are four advisers' do
-      FactoryGirl.create_list(:adviser, 4)
-      most_recent = Adviser.most_recently_edited
-
-      expect(most_recent.length).to eq(3)
-    end
-
-    it 'provides the three most recently edited advisers when there are four advisers' do
-      first_adviser = FactoryGirl.create(:adviser, updated_at: 2.weeks.ago)
-      second_adviser = FactoryGirl.create(:adviser, updated_at: 1.weeks.ago)
-      fourth_adviser = FactoryGirl.create(:adviser, updated_at: 3.weeks.ago)
-      FactoryGirl.create(:adviser, updated_at: 4.weeks.ago)
-
-      most_recent = Adviser.most_recently_edited
-
-      expect(most_recent[0]).to eq(second_adviser)
-      expect(most_recent[1]).to eq(first_adviser)
-      expect(most_recent[2]).to eq(fourth_adviser)
-    end
-  end
-
   describe '#on_firms_with_fca_number' do
     it 'returns advisers on firm and its trading names' do
       firm = FactoryGirl.create(:firm)

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -335,21 +335,4 @@ RSpec.describe Firm do
       expect(Firm.sorted_by_registered_name.map(&:registered_name)).to eq(sorted_names)
     end
   end
-
-  describe '.most_recently_updated scope' do
-    let(:firms) { FactoryGirl.create_pair(:firm, updated_at: Time.zone.now) }
-    let(:firm1) { firms[0] }
-    let(:firm2) { firms[1] }
-
-    it 'sorts the result set by the most recently updated record' do
-      expect(Firm.all).to eq([firm1, firm2])
-      firm2.update!(updated_at: (Time.zone.now + 1.hour))
-      expect(Firm.most_recently_updated).to eq([firm2, firm1])
-    end
-
-    it 'limits the number records based on the `limit` argument' do
-      expect(Firm.most_recently_updated).to eq([firm1, firm2])
-      expect(Firm.most_recently_updated(limit: 1)).to eq([firm1])
-    end
-  end
 end


### PR DESCRIPTION
These two scopes were introduced for the self_service dashboard feature in RAD, which has now been removed.