### PR TITLE
Add Adviser.sorted_by_name scope

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -37,6 +37,8 @@ class Adviser < ActiveRecord::Base
   after_commit :geocode
   after_commit :reindex_old_firm
 
+  scope :sorted_by_name, -> { order(:name) }
+
   def self.on_firms_with_fca_number(fca_number)
     firms = Firm.where(fca_number: fca_number)
     where(firm: firms)

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -274,4 +274,17 @@ RSpec.describe Adviser do
       expect(returned_advisers).to eq firm.advisers
     end
   end
+
+  describe '.sorted_by_name scope' do
+    let(:sorted_names)   { %w(A B C D E F G H) }
+    let(:unsorted_names) { %w(F C G E D H A B) }
+
+    before do
+      unsorted_names.each { |name| FactoryGirl.create(:adviser, name: name) }
+    end
+
+    it 'sorts the result set by the name field' do
+      expect(Adviser.sorted_by_name.map(&:name)).to eq(sorted_names)
+    end
+  end
 end


### PR DESCRIPTION
Adds a sorting scope for Advisers. To be used by the self-service dashboard in RAD.