### PR TITLE
Change business offering percentage fields to booleans.

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -1,14 +1,14 @@
 class Firm < ActiveRecord::Base
   include Geocodable
 
-  PERCENTAGE_ATTRIBUTES = [
-    :retirement_income_products_percent,
-    :pension_transfer_percent,
-    :long_term_care_percent,
-    :equity_release_percent,
-    :inheritance_tax_and_estate_planning_percent,
-    :wills_and_probate_percent,
-    :other_percent
+  BUSINESS_OFFERING_ATTRIBUTES = [
+    :retirement_income_products_flag,
+    :pension_transfer_flag,
+    :long_term_care_flag,
+    :equity_release_flag,
+    :inheritance_tax_and_estate_planning_flag,
+    :wills_and_probate_flag,
+    :other_flag
   ]
 
   scope :registered, -> { where.not(email_address: nil) }
@@ -80,11 +80,8 @@ class Firm < ActiveRecord::Base
     allow_blank: true,
     numericality: { only_integer: true }
 
-  validate :sum_of_percentages_equals_one_hundred
-
-  validates *PERCENTAGE_ATTRIBUTES,
-    presence: true,
-    numericality: { only_integer: true }
+  validates *BUSINESS_OFFERING_ATTRIBUTES,
+    inclusion: { in: [true, false] }
 
   validates :investment_sizes,
     length: { minimum: 1 }
@@ -130,7 +127,7 @@ class Firm < ActiveRecord::Base
       :allowed_payment_methods,
       :minimum_fixed_fee,
       :percent_total,
-      *PERCENTAGE_ATTRIBUTES,
+      *BUSINESS_OFFERING_ATTRIBUTES,
       :investment_sizes
     ]
   end
@@ -148,16 +145,5 @@ class Firm < ActiveRecord::Base
 
   def upcase_postcode
     address_postcode.upcase! if address_postcode.present?
-  end
-
-  def sum_of_percentages_equals_one_hundred
-    total = PERCENTAGE_ATTRIBUTES.sum { |a| read_attribute(a).to_i }
-
-    unless total == 100
-      errors.add(
-        :percent_total,
-        I18n.t('questionnaire.retirement_advice.percent_total.not_one_hundred')
-      )
-    end
   end
 end

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -49,27 +49,27 @@ class FirmSerializer < ActiveModel::Serializer
   end
 
   def retirement_income_products
-    object.retirement_income_products_percent
+    boolean_to_percentage object.retirement_income_products_flag
   end
 
   def pension_transfer
-    object.pension_transfer_percent
+    boolean_to_percentage object.pension_transfer_flag
   end
 
   def options_when_paying_for_care
-    object.long_term_care_percent
+    boolean_to_percentage object.long_term_care_flag
   end
 
   def equity_release
-    object.equity_release_percent
+    boolean_to_percentage object.equity_release_flag
   end
 
   def inheritance_tax_planning
-    object.inheritance_tax_and_estate_planning_percent
+    boolean_to_percentage object.inheritance_tax_and_estate_planning_flag
   end
 
   def wills_and_probate
-    object.wills_and_probate_percent
+    boolean_to_percentage object.wills_and_probate_flag
   end
 
   def _id
@@ -86,5 +86,11 @@ class FirmSerializer < ActiveModel::Serializer
 
   def investment_sizes
     object.investment_size_ids
+  end
+
+  private
+
+  def boolean_to_percentage(boolean)
+    boolean ? 100 : 0
   end
 end

--- a/db/migrate/20150630143001_change_percentage_fields_to_boolean_fields_on_firm.rb
+++ b/db/migrate/20150630143001_change_percentage_fields_to_boolean_fields_on_firm.rb
@@ -1,0 +1,35 @@
+class ChangePercentageFieldsToBooleanFieldsOnFirm < ActiveRecord::Migration
+  BUSINESS_OFFERING_ATTRIBUTE = [
+    :retirement_income_products,
+    :pension_transfer,
+    :long_term_care,
+    :equity_release,
+    :inheritance_tax_and_estate_planning,
+    :wills_and_probate,
+    :other]
+
+  def up
+    BUSINESS_OFFERING_ATTRIBUTE.each do |field|
+      # We add the boolean column
+      add_column :firms, "#{field}_flag".to_sym, :boolean, null: false, default: false
+      # Translate the old percentage values to the new boolean column
+      Firm.where("#{field}_percent > ?", 0).update_all("#{field}_flag" => true)
+      # And finally, remove the percentage column
+      remove_column :firms, "#{field}_percent".to_sym, :integer
+    end
+  end
+
+  def down
+    BUSINESS_OFFERING_ATTRIBUTE.each do |field|
+      # As above, but in reverse.
+      # Since we've lost information, we can only migrate back by figuring
+      #   true  => 100%
+      #   false => 0%
+      # Which won't validate since the fields won't add up to 100%, but it
+      # will work in a pinch.
+      add_column :firms, "#{field}_percent".to_sym, :integer
+      Firm.where("#{field}_flag" => true).update_all("#{field}_percent" => 100)
+      remove_column :firms, "#{field}_flag".to_sym, :boolean, null: false, default: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150423154732) do
+ActiveRecord::Schema.define(version: 20150630143001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,12 +79,12 @@ ActiveRecord::Schema.define(version: 20150423154732) do
   add_index "allowed_payment_methods_firms", ["firm_id", "allowed_payment_method_id"], name: "firms_allowed_payment_methods_index", unique: true, using: :btree
 
   create_table "firms", force: :cascade do |t|
-    t.integer  "fca_number",                                  null: false
-    t.string   "registered_name",                             null: false
+    t.integer  "fca_number",                                               null: false
+    t.string   "registered_name",                                          null: false
     t.string   "email_address"
     t.string   "telephone_number"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.datetime "created_at",                                               null: false
+    t.datetime "updated_at",                                               null: false
     t.string   "address_line_one"
     t.string   "address_line_two"
     t.string   "address_town"
@@ -93,16 +93,16 @@ ActiveRecord::Schema.define(version: 20150423154732) do
     t.boolean  "free_initial_meeting"
     t.integer  "initial_meeting_duration_id"
     t.integer  "minimum_fixed_fee"
-    t.integer  "retirement_income_products_percent"
-    t.integer  "pension_transfer_percent"
-    t.integer  "long_term_care_percent"
-    t.integer  "equity_release_percent"
-    t.integer  "inheritance_tax_and_estate_planning_percent"
-    t.integer  "wills_and_probate_percent"
-    t.integer  "other_percent"
     t.integer  "parent_id"
     t.float    "latitude"
     t.float    "longitude"
+    t.boolean  "retirement_income_products_flag",          default: false, null: false
+    t.boolean  "pension_transfer_flag",                    default: false, null: false
+    t.boolean  "long_term_care_flag",                      default: false, null: false
+    t.boolean  "equity_release_flag",                      default: false, null: false
+    t.boolean  "inheritance_tax_and_estate_planning_flag", default: false, null: false
+    t.boolean  "wills_and_probate_flag",                   default: false, null: false
+    t.boolean  "other_flag",                               default: false, null: false
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -20,13 +20,13 @@ FactoryGirl.define do
     ongoing_advice_fee_structures { create_list(:ongoing_advice_fee_structure, rand(1..3)) }
     allowed_payment_methods { create_list(:allowed_payment_method, rand(1..3)) }
     investment_sizes { create_list(:investment_size, rand(5..10)) }
-    retirement_income_products_percent 15
-    pension_transfer_percent 15
-    long_term_care_percent 15
-    equity_release_percent 15
-    inheritance_tax_and_estate_planning_percent 15
-    wills_and_probate_percent 15
-    other_percent 10
+    retirement_income_products_flag true
+    pension_transfer_flag true
+    long_term_care_flag true
+    equity_release_flag true
+    inheritance_tax_and_estate_planning_flag true
+    wills_and_probate_flag true
+    other_flag true
     latitude { Faker::Address.latitude.to_f.round(6) }
     longitude { Faker::Address.longitude.to_f.round(6) }
 
@@ -37,13 +37,13 @@ FactoryGirl.define do
     end
 
     factory :firm_with_no_business_split do
-      retirement_income_products_percent 0
-      pension_transfer_percent 0
-      long_term_care_percent 0
-      equity_release_percent 0
-      inheritance_tax_and_estate_planning_percent 0
-      wills_and_probate_percent 0
-      other_percent 0
+      retirement_income_products_flag false
+      pension_transfer_flag false
+      long_term_care_flag false
+      equity_release_flag false
+      inheritance_tax_and_estate_planning_flag false
+      wills_and_probate_flag false
+      other_flag false
     end
 
     factory :firm_with_advisers do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -191,16 +191,6 @@ RSpec.describe Firm do
       end
     end
 
-    describe 'business income breakdown' do
-      context 'when sum not equal to 100' do
-        before do
-          firm.retirement_income_products_percent = 5
-        end
-
-        it { is_expected.not_to be_valid }
-      end
-    end
-
     describe 'investment size' do
       context 'when none assigned' do
         before { firm.investment_sizes = [] }

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -59,27 +59,27 @@ RSpec.describe FirmSerializer do
     end
 
     it 'exposes `retirement_income_products`' do
-      expect(subject[:retirement_income_products]).to eq(firm.retirement_income_products_percent)
+      expect(subject[:retirement_income_products]).to eq(firm.retirement_income_products_flag ? 100 : 0)
     end
 
     it 'exposes `pension_transfer`' do
-      expect(subject[:pension_transfer]).to eq(firm.pension_transfer_percent)
+      expect(subject[:pension_transfer]).to eq(firm.pension_transfer_flag ? 100 : 0)
     end
 
     it 'exposes `options_when_paying_for_care`' do
-      expect(subject[:options_when_paying_for_care]).to eq(firm.long_term_care_percent)
+      expect(subject[:options_when_paying_for_care]).to eq(firm.long_term_care_flag ? 100 : 0)
     end
 
     it 'exposes `equity_release`' do
-      expect(subject[:equity_release]).to eq(firm.equity_release_percent)
+      expect(subject[:equity_release]).to eq(firm.equity_release_flag ? 100 : 0)
     end
 
     it 'exposes `inheritance_tax_planning`' do
-      expect(subject[:inheritance_tax_planning]).to eq(firm.inheritance_tax_and_estate_planning_percent)
+      expect(subject[:inheritance_tax_planning]).to eq(firm.inheritance_tax_and_estate_planning_flag ? 100 : 0)
     end
 
     it 'exposes `wills_and_probate`' do
-      expect(subject[:wills_and_probate]).to eq(firm.wills_and_probate_percent)
+      expect(subject[:wills_and_probate]).to eq(firm.wills_and_probate_flag ? 100 : 0)
     end
 
     it 'exposes `other_advice_method_ids`' do


### PR DESCRIPTION
I decided not to propagate this change to ElasticSearch, because that would mean doing some mucking around with the live server to make all the databases and codebases align. It's possible that we'll do that, but given that this is a priority change and it'll be a while until this is deployed to production — we'll defer it.

`firm_serializer` is responsible for converting booleans to percentages.