### PR TITLE
Move `website_address` attribute from principal to firm.

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -45,6 +45,11 @@ class Firm < ActiveRecord::Base
     length: { maximum: 30 },
     format: { with: /\A[0-9 ]+\z/ }
 
+  validates :website_address,
+    allow_blank: true,
+    length: { maximum: 100 },
+    format: { with: /\Ahttps?:\/\/\S+\.\S+/ }
+
   validates :address_line_one,
     presence: true,
     length: { maximum: 100 }

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -29,11 +29,6 @@ class Principal < ActiveRecord::Base
     length: { maximum: 50 },
     format: { with: /\A[0-9 ]+\z/ }
 
-  validates :website_address,
-    allow_blank: true,
-    length: { maximum: 100 },
-    format: { with: /\Ahttps?:\/\/\S+\.\S+/ }
-
   validates_acceptance_of :confirmed_disclaimer, accept: true
 
   validate :match_fca_number, if: :fca_number?
@@ -55,7 +50,6 @@ class Principal < ActiveRecord::Base
   def field_order
     [
       :fca_number,
-      :website_address,
       :first_name,
       :last_name,
       :job_title,

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -44,10 +44,6 @@ class FirmSerializer < ActiveModel::Serializer
     object.postcode_searchable?
   end
 
-  def website_address
-    object.principal.try(:website_address)
-  end
-
   def retirement_income_products
     boolean_to_percentage object.retirement_income_products_flag
   end

--- a/db/migrate/20150706102943_move_website_from_principals_to_firms.rb
+++ b/db/migrate/20150706102943_move_website_from_principals_to_firms.rb
@@ -1,0 +1,25 @@
+class MoveWebsiteFromPrincipalsToFirms < ActiveRecord::Migration
+  def up
+    add_column :firms, :website_address, :string
+
+    Principal.all.each do |principal|
+      Firm.where(fca_number: principal.fca_number)
+           .update_all(website_address: principal.website_address)
+    end
+
+    remove_column :principals, :website_address, :string
+  end
+
+  def down
+    add_column :principals, :website_address, :string
+
+    # This doesn't reverse the migration cleanly, but takes the website address
+    # of the principal's parent firm. It will discard all websites on trading
+    # name firms.
+    Principal.all.each do |principal|
+      principal.update(website_address: principal.firm.try(:website_address))
+    end
+
+    remove_column :firms, :website_address, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150630143001) do
+ActiveRecord::Schema.define(version: 20150706102943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 20150630143001) do
     t.boolean  "inheritance_tax_and_estate_planning_flag", default: false, null: false
     t.boolean  "wills_and_probate_flag",                   default: false, null: false
     t.boolean  "other_flag",                               default: false, null: false
+    t.string   "website_address"
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree
@@ -216,7 +217,6 @@ ActiveRecord::Schema.define(version: 20150630143001) do
   create_table "principals", force: :cascade do |t|
     t.integer  "fca_number"
     t.string   "token"
-    t.string   "website_address"
     t.string   "first_name"
     t.string   "last_name"
     t.string   "job_title"

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     registered_name
     email_address { Faker::Internet.email }
     telephone_number { Faker::Base.numerify('##### ### ###') }
+    website_address { Faker::Internet.url }
     address_line_one { Faker::Address.street_address }
     address_line_two { Faker::Address.secondary_address }
     address_town { Faker::Address.city }

--- a/spec/factories/principal.rb
+++ b/spec/factories/principal.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email_address { Faker::Internet.email(first_name) }
-    website_address { Faker::Internet.url }
     job_title { Faker::Name.title }
     telephone_number { Faker::Base.numerify('##### ### ###') }
     confirmed_disclaimer true

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -93,6 +93,22 @@ RSpec.describe Firm do
       end
     end
 
+    describe 'Website address' do
+      context 'when provided' do
+        it 'must not exceed 100 characters' do
+          expect(build(:firm, website_address: "#{'a' * 100}.com")).not_to be_valid
+        end
+
+        it 'must include the protocol segment' do
+          expect(build(:firm, website_address: 'www.google.com')).not_to be_valid
+        end
+
+        it 'must be a reasonably valid URL' do
+          expect(build(:firm, website_address: 'http://a')).not_to be_valid
+        end
+      end
+    end
+
     describe 'address line 1' do
       context 'when missing' do
         before { firm.address_line_one = nil }

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -175,29 +175,12 @@ RSpec.describe Principal do
         expect(build(:principal, telephone_number: '1 abcd')).to_not be_valid
       end
     end
-
-    describe 'Website address' do
-      context 'when provided' do
-        it 'must not exceed 100 characters' do
-          expect(build(:principal, website_address: "#{'a' * 100}.com")).not_to be_valid
-        end
-
-        it 'must include the protocol segment' do
-          expect(build(:principal, website_address: 'www.google.com')).not_to be_valid
-        end
-
-        it 'must be a reasonably valid URL' do
-          expect(build(:principal, website_address: 'http://a')).not_to be_valid
-        end
-      end
-    end
   end
 
   describe 'dough #field_order' do
     let(:fields) do
       [
         :fca_number,
-        :website_address,
         :first_name,
         :last_name,
         :job_title,

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe FirmSerializer do
     end
 
     it 'exposes `website_address`' do
-      expect(subject[:website_address]).to eql(firm.principal.website_address)
+      expect(subject[:website_address]).to eql(firm.website_address)
     end
 
     it 'exposes `email_address`' do


### PR DESCRIPTION
Firms and trading names should have their own websites, not just use the principal's one.