### PR TITLE
Make advice types field required

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -88,6 +88,12 @@ class Firm < ActiveRecord::Base
   validates *ADVICE_TYPES_ATTRIBUTES,
     inclusion: { in: [true, false] }
 
+  validate do
+    unless advice_types.values.any?
+      errors.add(:advice_types, :invalid)
+    end
+  end
+
   validates :investment_sizes,
     length: { minimum: 1 }
 
@@ -140,6 +146,10 @@ class Firm < ActiveRecord::Base
   def geocode
     return if destroyed?
     GeocodeFirmJob.perform_later(self)
+  end
+
+  def advice_types
+    ADVICE_TYPES_ATTRIBUTES.map { |a| [a, self[a]] }.to_h
   end
 
   private

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -7,8 +7,7 @@ class Firm < ActiveRecord::Base
     :long_term_care_flag,
     :equity_release_flag,
     :inheritance_tax_and_estate_planning_flag,
-    :wills_and_probate_flag,
-    :other_flag
+    :wills_and_probate_flag
   ]
 
   scope :registered, -> { where.not(email_address: nil) }

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -1,7 +1,7 @@
 class Firm < ActiveRecord::Base
   include Geocodable
 
-  BUSINESS_OFFERING_ATTRIBUTES = [
+  ADVICE_TYPES_ATTRIBUTES = [
     :retirement_income_products_flag,
     :pension_transfer_flag,
     :long_term_care_flag,
@@ -85,7 +85,7 @@ class Firm < ActiveRecord::Base
     allow_blank: true,
     numericality: { only_integer: true }
 
-  validates *BUSINESS_OFFERING_ATTRIBUTES,
+  validates *ADVICE_TYPES_ATTRIBUTES,
     inclusion: { in: [true, false] }
 
   validates :investment_sizes,
@@ -132,7 +132,7 @@ class Firm < ActiveRecord::Base
       :allowed_payment_methods,
       :minimum_fixed_fee,
       :percent_total,
-      *BUSINESS_OFFERING_ATTRIBUTES,
+      *ADVICE_TYPES_ATTRIBUTES,
       :investment_sizes
     ]
   end

--- a/db/migrate/20150630143001_change_percentage_fields_to_boolean_fields_on_firm.rb
+++ b/db/migrate/20150630143001_change_percentage_fields_to_boolean_fields_on_firm.rb
@@ -1,5 +1,5 @@
 class ChangePercentageFieldsToBooleanFieldsOnFirm < ActiveRecord::Migration
-  BUSINESS_OFFERING_ATTRIBUTE = [
+  ADVICE_TYPES_ATTRIBUTES = [
     :retirement_income_products,
     :pension_transfer,
     :long_term_care,
@@ -9,7 +9,7 @@ class ChangePercentageFieldsToBooleanFieldsOnFirm < ActiveRecord::Migration
     :other]
 
   def up
-    BUSINESS_OFFERING_ATTRIBUTE.each do |field|
+    ADVICE_TYPES_ATTRIBUTES.each do |field|
       # We add the boolean column
       add_column :firms, "#{field}_flag".to_sym, :boolean, null: false, default: false
       # Translate the old percentage values to the new boolean column
@@ -20,7 +20,7 @@ class ChangePercentageFieldsToBooleanFieldsOnFirm < ActiveRecord::Migration
   end
 
   def down
-    BUSINESS_OFFERING_ATTRIBUTE.each do |field|
+    ADVICE_TYPES_ATTRIBUTES.each do |field|
       # As above, but in reverse.
       # Since we've lost information, we can only migrate back by figuring
       #   true  => 100%

--- a/db/migrate/20150716123032_remove_other_flag_from_firms.rb
+++ b/db/migrate/20150716123032_remove_other_flag_from_firms.rb
@@ -1,0 +1,5 @@
+class RemoveOtherFlagFromFirms < ActiveRecord::Migration
+  def change
+    remove_column :firms, :other_flag, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150706102943) do
+ActiveRecord::Schema.define(version: 20150716123032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,7 +102,6 @@ ActiveRecord::Schema.define(version: 20150706102943) do
     t.boolean  "equity_release_flag",                      default: false, null: false
     t.boolean  "inheritance_tax_and_estate_planning_flag", default: false, null: false
     t.boolean  "wills_and_probate_flag",                   default: false, null: false
-    t.boolean  "other_flag",                               default: false, null: false
     t.string   "website_address"
   end
 

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -27,7 +27,6 @@ FactoryGirl.define do
     equity_release_flag true
     inheritance_tax_and_estate_planning_flag true
     wills_and_probate_flag true
-    other_flag true
     latitude { Faker::Address.latitude.to_f.round(6) }
     longitude { Faker::Address.longitude.to_f.round(6) }
 
@@ -44,7 +43,6 @@ FactoryGirl.define do
       equity_release_flag false
       inheritance_tax_and_estate_planning_flag false
       wills_and_probate_flag false
-      other_flag false
     end
 
     factory :firm_with_advisers do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -362,8 +362,7 @@ RSpec.describe Firm do
         long_term_care_flag: subject.long_term_care_flag,
         equity_release_flag: subject.equity_release_flag,
         inheritance_tax_and_estate_planning_flag: subject.inheritance_tax_and_estate_planning_flag,
-        wills_and_probate_flag: subject.wills_and_probate_flag,
-        other_flag: subject.other_flag
+        wills_and_probate_flag: subject.wills_and_probate_flag
       })
     end
   end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -214,6 +214,18 @@ RSpec.describe Firm do
         it { is_expected.not_to be_valid }
       end
     end
+
+    describe 'advice types' do
+      context 'when none assigned' do
+        before do
+          Firm::ADVICE_TYPES_ATTRIBUTES.each do |attribute|
+            firm[attribute] = false
+          end
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+    end
   end
 
   describe '#full_street_address' do
@@ -339,6 +351,20 @@ RSpec.describe Firm do
 
     it 'sorts the result set by the registered_name field' do
       expect(Firm.sorted_by_registered_name.map(&:registered_name)).to eq(sorted_names)
+    end
+  end
+
+  describe '#advice_types' do
+    it 'returns a hash of advice types' do
+      expect(subject.advice_types).to eq({
+        retirement_income_products_flag: subject.retirement_income_products_flag,
+        pension_transfer_flag: subject.pension_transfer_flag,
+        long_term_care_flag: subject.long_term_care_flag,
+        equity_release_flag: subject.equity_release_flag,
+        inheritance_tax_and_estate_planning_flag: subject.inheritance_tax_and_estate_planning_flag,
+        wills_and_probate_flag: subject.wills_and_probate_flag,
+        other_flag: subject.other_flag
+      })
     end
   end
 end


### PR DESCRIPTION
Also:

* Rename 'business split' to 'advice types'.
* Remove the 'other' type of advice.