### PR TITLE
Adding an onboarding status check to principal

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -113,6 +113,10 @@ class Firm < ActiveRecord::Base
   after_commit :geocode, if: :valid?
   after_commit :delete_elastic_search_entry, if: :destroyed?
 
+  def registered?
+    email_address.present?
+  end
+
   def telephone_number
     return nil unless self[:telephone_number]
 

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -71,7 +71,31 @@ class Principal < ActiveRecord::Base
     "#{first_name} #{last_name}"
   end
 
+  def next_onboarding_action
+    registered_firms = main_firm_with_trading_names.registered
+
+    if registered_firms.empty?
+      :complete_a_firm
+    elsif needs_advisers?(registered_firms)
+      :complete_an_adviser
+    else
+      :onboarded
+    end
+  end
+
   private
+
+  def needs_advisers?(firm_list)
+     no_remote_firms?(firm_list) && no_advisers_for?(firm_list)
+  end
+
+  def no_remote_firms?(firm_list)
+    firm_list.none? { |f| f.primary_advice_method == :remote }
+  end
+
+  def no_advisers_for?(firm_list)
+    firm_list.none? { |f| f.advisers.present? }
+  end
 
   def find_subsidiary(subsidiary)
     firm.subsidiaries.find_or_initialize_by(

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -74,11 +74,12 @@ class Principal < ActiveRecord::Base
   def next_onboarding_action
     registered_firms = main_firm_with_trading_names.registered
 
-    if registered_firms.empty?
+    case
+    when registered_firms.empty?
       :complete_a_firm
-    elsif any_remote_firms?(registered_firms)
+    when any_remote_firms?(registered_firms)
       :onboarded
-    elsif needs_advisers?(registered_firms)
+    when needs_advisers?(registered_firms)
       :complete_an_adviser
     else
       :onboarded

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -76,6 +76,8 @@ class Principal < ActiveRecord::Base
 
     if registered_firms.empty?
       :complete_a_firm
+    elsif any_remote_firms?(registered_firms)
+      :onboarded
     elsif needs_advisers?(registered_firms)
       :complete_an_adviser
     else
@@ -85,16 +87,12 @@ class Principal < ActiveRecord::Base
 
   private
 
+  def any_remote_firms?(firm_list)
+    firm_list.any? { |f| f.primary_advice_method == :remote }
+  end
+
   def needs_advisers?(firm_list)
-     no_remote_firms?(firm_list) && no_advisers_for?(firm_list)
-  end
-
-  def no_remote_firms?(firm_list)
-    firm_list.none? { |f| f.primary_advice_method == :remote }
-  end
-
-  def no_advisers_for?(firm_list)
-    firm_list.none? { |f| f.advisers.present? }
+     firm_list.none? { |f| f.advisers.present? }
   end
 
   def find_subsidiary(subsidiary)

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Firm do
     end
   end
 
+  describe '#registered?' do
+    it 'is false if the firm has no email address' do
+      firm.email_address = nil
+      expect(firm).not_to be_registered
+    end
+
+    it 'is true if the firm has an email address' do
+      firm.email_address = 'acme@example.com'
+      expect(firm).to be_registered
+    end
+  end
+
   describe '#telephone_number' do
     context 'when `nil`' do
       it 'returns `nil`' do

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -204,10 +204,11 @@ RSpec.describe Principal do
   end
 
   describe '#next_onboarding_action' do
-    context 'when principal has no parent firm' do
+    context 'when principal has no firms or trading names' do
       before :each do
         principal.firm.destroy
         principal.reload
+        expect(principal.main_firm_with_trading_names).to be_empty
       end
 
       it 'returns :complete_a_firm' do
@@ -221,9 +222,9 @@ RSpec.describe Principal do
         expect(Firm.where(fca_number: principal.fca_number).count).to eql(1)
       end
 
-      context 'and the parent firm has no email address' do
+      context 'and the parent firm is not registered' do
         before :each do
-          expect(principal.firm.email_address).to be_blank
+          expect(principal.firm).not_to be_registered
         end
 
         it 'returns :complete_a_firm' do
@@ -231,10 +232,11 @@ RSpec.describe Principal do
         end
       end
 
-      context 'and the parent firm has an email address' do
+      context 'and the parent firm is registered' do
         before :each do
           principal.firm.update_column(:email_address, 'acme@example.com')
           principal.reload
+          expect(principal.firm).to be_registered
         end
 
         context 'and the firm primarily gives remote advice' do

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Principal do
             principal.reload
           end
 
-          context 'and has at least one in-person adviser' do
+          context 'and has at least one adviser' do
             before :each do
               create(:adviser, firm: principal.firm)
               principal.reload

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -318,50 +318,7 @@ RSpec.describe Principal do
           principal.reload
         end
 
-        context 'and neither firm has advisers' do
-          before :each do
-            expect(parent_firm.advisers.any?).to eql(false)
-            expect(trading_name.advisers.any?).to eql(false)
-          end
-
-          it 'returns :onboarded' do
-            expect(principal.next_onboarding_action).to eql(:onboarded)
-          end
-        end
-
-        context 'and the parent firm has advisers' do
-          before :each do
-            create(:adviser, firm: parent_firm)
-            principal.reload
-          end
-
-          it 'returns :onboarded' do
-            expect(principal.next_onboarding_action).to eql(:onboarded)
-          end
-        end
-
-        context 'and the trading name has advisers' do
-          before :each do
-            create(:adviser, firm: trading_name)
-            principal.reload
-          end
-
-          it 'returns :onboarded' do
-            expect(principal.next_onboarding_action).to eql(:onboarded)
-          end
-        end
-
-        context 'and both firms have advisers' do
-          before :each do
-            create(:adviser, firm: parent_firm)
-            create(:adviser, firm: trading_name)
-            principal.reload
-          end
-
-          it 'returns :onboarded' do
-            expect(principal.next_onboarding_action).to eql(:onboarded)
-          end
-        end
+        it_behaves_like 'at least one remote firm'
       end
 
       context 'if at least one firm gives remote advice' do
@@ -373,49 +330,7 @@ RSpec.describe Principal do
             principal.reload
           end
 
-          context 'and neither firm has advisers' do
-            before :each do
-              expect(parent_firm.advisers.any?).to eql(false)
-              expect(trading_name.advisers.any?).to eql(false)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
-
-          context 'and parent firm has advisers' do
-            before :each do
-              create(:adviser, firm: parent_firm)
-              expect(trading_name.advisers.any?).to eql(false)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
-
-          context 'and trading name has advisers' do
-            before :each do
-              expect(parent_firm.advisers.any?).to eql(false)
-              create(:adviser, firm: trading_name)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
-
-          context 'and both firms have advisers' do
-            before :each do
-              create(:adviser, firm: parent_firm)
-              create(:adviser, firm: trading_name)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
+          it_behaves_like 'at least one remote firm'
         end
 
         context 'trading name gives remote advice' do
@@ -426,49 +341,7 @@ RSpec.describe Principal do
             principal.reload
           end
 
-          context 'and neither firm has advisers' do
-            before :each do
-              expect(parent_firm.advisers.any?).to eql(false)
-              expect(trading_name.advisers.any?).to eql(false)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
-
-          context 'and parent firm has advisers' do
-            before :each do
-              create(:adviser, firm: parent_firm)
-              expect(trading_name.advisers.any?).to eql(false)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
-
-          context 'and trading name has advisers' do
-            before :each do
-              expect(parent_firm.advisers.any?).to eql(false)
-              create(:adviser, firm: trading_name)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
-
-          context 'and both firms have advisers' do
-            before :each do
-              create(:adviser, firm: parent_firm)
-              create(:adviser, firm: trading_name)
-            end
-
-            it 'returns :onboarded' do
-              expect(principal.next_onboarding_action).to eql(:onboarded)
-            end
-          end
+          it_behaves_like 'at least one remote firm'
         end
       end
 

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -202,4 +202,325 @@ RSpec.describe Principal do
       expect(Firm.where(id: firm.id)).to be_empty
     end
   end
+
+  describe '#next_onboarding_action' do
+    context 'when principal has no parent firm' do
+      before :each do
+        principal.firm.destroy
+        principal.reload
+      end
+
+      it 'returns :complete_a_firm' do
+        expect(principal.next_onboarding_action).to eql(:complete_a_firm)
+      end
+    end
+
+    context 'when principal only has a parent firm' do
+      before :each do
+        expect(principal.firm).not_to be_nil
+        expect(Firm.where(fca_number: principal.fca_number).count).to eql(1)
+      end
+
+      context 'and the parent firm has no email address' do
+        before :each do
+          expect(principal.firm.email_address).to be_blank
+        end
+
+        it 'returns :complete_a_firm' do
+          expect(principal.next_onboarding_action).to eql(:complete_a_firm)
+        end
+      end
+
+      context 'and the parent firm has an email address' do
+        before :each do
+          principal.firm.update_column(:email_address, 'acme@example.com')
+          principal.reload
+        end
+
+        context 'and the firm primarily gives remote advice' do
+          before :each do
+            principal.firm.in_person_advice_methods.destroy_all
+            principal.firm.other_advice_methods << create(:other_advice_method)
+            principal.reload
+          end
+
+          context 'and the firm has no advisers' do
+            before :each do
+              expect(principal.firm.advisers.any?).to eql(false)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and the firm has advisers' do
+            before :each do
+              create(:adviser, firm: principal.firm)
+              principal.reload
+              expect(principal.firm.advisers.any?).to eql(true)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+        end
+
+        context 'and the firm primarily gives in-person advice' do
+          before :each do
+            principal.firm.in_person_advice_methods << create(:in_person_advice_method)
+            principal.reload
+          end
+
+          context 'and has at least one in-person adviser' do
+            before :each do
+              create(:adviser, firm: principal.firm)
+              principal.reload
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and does not have at least one adviser' do
+            before :each do
+              expect(principal.firm.advisers.any?).to eql(false)
+            end
+
+            it 'returns :complete_an_adviser' do
+              expect(principal.next_onboarding_action).to eql(:complete_an_adviser)
+            end
+          end
+        end
+      end
+    end
+
+    context 'when principal has a parent firm and a trading name' do
+      let(:parent_firm)   { principal.firm }
+      let!(:trading_name) { create(:firm, registered_name: 'cabbage', parent_id: parent_firm.id, fca_number: principal.fca_number) }
+
+      before :each do
+        parent_firm.update_column(:email_address, 'acme@example.com')
+        principal.reload
+        expect(Firm.where(fca_number: principal.fca_number).count).to eql(2)
+      end
+
+      context 'and neither firm give in-person advice' do
+        before :each do
+          parent_firm.in_person_advice_methods.destroy_all
+          parent_firm.other_advice_methods << create(:other_advice_method)
+          trading_name.in_person_advice_methods.destroy_all
+          trading_name.other_advice_methods << create(:other_advice_method)
+          principal.reload
+        end
+
+        context 'and neither firm has advisers' do
+          before :each do
+            expect(parent_firm.advisers.any?).to eql(false)
+            expect(trading_name.advisers.any?).to eql(false)
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+
+        context 'and the parent firm has advisers' do
+          before :each do
+            create(:adviser, firm: parent_firm)
+            principal.reload
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+
+        context 'and the trading name has advisers' do
+          before :each do
+            create(:adviser, firm: trading_name)
+            principal.reload
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+
+        context 'and both firms have advisers' do
+          before :each do
+            create(:adviser, firm: parent_firm)
+            create(:adviser, firm: trading_name)
+            principal.reload
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+      end
+
+      context 'if at least one firm gives remote advice' do
+        context 'parent firm gives remote advice' do
+          before :each do
+            parent_firm.in_person_advice_methods.destroy_all
+            parent_firm.other_advice_methods << create(:other_advice_method)
+            trading_name.in_person_advice_methods << create(:in_person_advice_method)
+            principal.reload
+          end
+
+          context 'and neither firm has advisers' do
+            before :each do
+              expect(parent_firm.advisers.any?).to eql(false)
+              expect(trading_name.advisers.any?).to eql(false)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and parent firm has advisers' do
+            before :each do
+              create(:adviser, firm: parent_firm)
+              expect(trading_name.advisers.any?).to eql(false)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and trading name has advisers' do
+            before :each do
+              expect(parent_firm.advisers.any?).to eql(false)
+              create(:adviser, firm: trading_name)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and both firms have advisers' do
+            before :each do
+              create(:adviser, firm: parent_firm)
+              create(:adviser, firm: trading_name)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+        end
+
+        context 'trading name gives remote advice' do
+          before :each do
+            parent_firm.in_person_advice_methods << create(:in_person_advice_method)
+            trading_name.in_person_advice_methods.destroy_all
+            trading_name.other_advice_methods << create(:other_advice_method)
+            principal.reload
+          end
+
+          context 'and neither firm has advisers' do
+            before :each do
+              expect(parent_firm.advisers.any?).to eql(false)
+              expect(trading_name.advisers.any?).to eql(false)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and parent firm has advisers' do
+            before :each do
+              create(:adviser, firm: parent_firm)
+              expect(trading_name.advisers.any?).to eql(false)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and trading name has advisers' do
+            before :each do
+              expect(parent_firm.advisers.any?).to eql(false)
+              create(:adviser, firm: trading_name)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+
+          context 'and both firms have advisers' do
+            before :each do
+              create(:adviser, firm: parent_firm)
+              create(:adviser, firm: trading_name)
+            end
+
+            it 'returns :onboarded' do
+              expect(principal.next_onboarding_action).to eql(:onboarded)
+            end
+          end
+        end
+      end
+
+      context 'and both firms give in-person advice' do
+        before :each do
+          parent_firm.in_person_advice_methods  << create(:in_person_advice_method)
+          trading_name.in_person_advice_methods << create(:in_person_advice_method)
+          principal.reload
+        end
+
+        context 'and neither firm has advisers' do
+          before :each do
+            expect(parent_firm.advisers.any?).to eql(false)
+            expect(trading_name.advisers.any?).to eql(false)
+          end
+
+          it 'returns :complete_an_adviser' do
+            expect(principal.next_onboarding_action).to eql(:complete_an_adviser)
+          end
+        end
+
+        context 'and parent firm has advisers' do
+          before :each do
+            create(:adviser, firm: parent_firm)
+            expect(trading_name.advisers.any?).to eql(false)
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+
+        context 'and trading name has advisers' do
+          before :each do
+            expect(parent_firm.advisers.any?).to eql(false)
+            create(:adviser, firm: trading_name)
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+
+        context 'and both firms have advisers' do
+          before :each do
+            create(:adviser, firm: parent_firm)
+            create(:adviser, firm: trading_name)
+          end
+
+          it 'returns :onboarded' do
+            expect(principal.next_onboarding_action).to eql(:onboarded)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/at_least_one_remote_firm.rb
+++ b/spec/support/shared_examples/at_least_one_remote_firm.rb
@@ -1,0 +1,53 @@
+##
+# Needs:
+#   principal    = instance of Principal with two firms attached (parent_firm and trading_name)
+#   parent_firm  = an instance of Firm with the same FCA Number as the Principal but no parent firm
+#   trading_name = an instance of Firm with the same FCA Number as the Principal and the parent_firm as the parent firm
+RSpec.shared_examples 'at least one remote firm' do
+  context 'and neither firm has advisers' do
+    before :each do
+      expect(parent_firm.advisers.any?).to eql(false)
+      expect(trading_name.advisers.any?).to eql(false)
+    end
+
+    it 'returns :onboarded' do
+      expect(principal.next_onboarding_action).to eql(:onboarded)
+    end
+  end
+
+  context 'and the parent firm has advisers' do
+    before :each do
+      create(:adviser, firm: parent_firm)
+      expect(trading_name.advisers.any?).to eql(false)
+      principal.reload
+    end
+
+    it 'returns :onboarded' do
+      expect(principal.next_onboarding_action).to eql(:onboarded)
+    end
+  end
+
+  context 'and the trading name has advisers' do
+    before :each do
+      expect(parent_firm.advisers.any?).to eql(false)
+      create(:adviser, firm: trading_name)
+      principal.reload
+    end
+
+    it 'returns :onboarded' do
+      expect(principal.next_onboarding_action).to eql(:onboarded)
+    end
+  end
+
+  context 'and both firms have advisers' do
+    before :each do
+      create(:adviser, firm: parent_firm)
+      create(:adviser, firm: trading_name)
+      principal.reload
+    end
+
+    it 'returns :onboarded' do
+      expect(principal.next_onboarding_action).to eql(:onboarded)
+    end
+  end
+end


### PR DESCRIPTION
We need to know how far through the onboarding process a principal is.

The aim is to get a Principal to the point where they have at least one firm on the register.

The rules that we are implementing here are as follows:

1. If a Principal has no registered firms (at the moment determined by whether or not they have made it far enough to supply an email address) then they should be prompted to `:complete_a_firm`
2. If they have at least one completed firm then the next check is to see whether or not they should be setting up an adviser. A firm should be prompted to :complete_an_adviser if
    1. They have no remote firms (i.e. ones that primarily offer advice without an in-person visit). This is because remote firms do not need advisers so they will be eligible to be on the register without advisers and therefore the Principal will have a firm on the register
    2. They have no advisers.

Hopefully this makes sense! :)