### PR TITLE
Simplify and optimise languages validation

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -105,7 +105,7 @@ class Firm < ActiveRecord::Base
     presence: true
 
   validate :languages do
-    unless languages.all? { |lang| Firm.available_languages.find { |l| l.iso_639_1 == lang } }
+    unless languages.all? { |lang| AVAILABLE_LANGUAGES_ISO_639_1_CODES.include?(lang) }
       errors.add(:languages, :invalid)
     end
   end
@@ -124,8 +124,12 @@ class Firm < ActiveRecord::Base
   after_commit :geocode, if: :valid?
   after_commit :delete_elastic_search_entry, if: :destroyed?
 
+  AVAILABLE_LANGUAGES = LanguageList::COMMON_LANGUAGES - [LanguageList::LanguageInfo.find('en')].freeze
+  AVAILABLE_LANGUAGES_ISO_639_1_CODES = Set.new(AVAILABLE_LANGUAGES.map(&:iso_639_1)).freeze
+
+  # Maintains existing interface
   def self.available_languages
-    LanguageList::COMMON_LANGUAGES - [LanguageList::LanguageInfo.find('en')]
+    AVAILABLE_LANGUAGES
   end
 
   def registered?


### PR DESCRIPTION
Now caches the available languages at class load time and uses the Set
data structure to simplify and optimise validation of selected
languages.

The existing implementation involved a lot of nested loops which meant
its runtime would be sensitive to changes in the number of languages
available and selected. Our rough estimate of its running time
complexity was O(n^3).

The new approach guarantees the running time will not vary so much. It
should now be O(n).

@neoeno 