### PR TITLE
Cascade delete offices from firms

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -25,7 +25,7 @@ class Firm < ActiveRecord::Base
   belongs_to :parent, class_name: 'Firm'
 
   has_many :advisers, dependent: :destroy
-  has_many :offices, -> { order created_at: :asc }
+  has_many :offices, -> { order created_at: :asc }, dependent: :destroy
   has_many :subsidiaries, class_name: 'Firm', foreign_key: :parent_id, dependent: :destroy
   has_many :trading_names, class_name: 'Firm', foreign_key: :parent_id, dependent: :destroy
   has_many :qualifications, -> { reorder('').uniq }, through: :advisers

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -69,5 +69,15 @@ FactoryGirl.define do
     factory :firm_with_principal do
       principal { create(:principal) }
     end
+
+    factory :firm_with_offices do
+      transient do
+        offices_count 3
+      end
+
+      after(:create) do |firm, evaluator|
+        create_list(:office, evaluator.offices_count, firm: firm)
+      end
+    end
   end
 end

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -70,7 +70,7 @@ FactoryGirl.define do
       principal { create(:principal) }
     end
 
-    factory :firm_with_offices do
+    trait :with_offices do
       transient do
         offices_count 3
       end
@@ -79,5 +79,7 @@ FactoryGirl.define do
         create_list(:office, evaluator.offices_count, firm: firm)
       end
     end
+
+    factory :firm_with_offices, traits: [:with_offices]
   end
 end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -478,11 +478,22 @@ RSpec.describe Firm do
     context 'when the firm has subsidiaries' do
       let(:firm) { create(:firm_with_trading_names) }
 
-      it 'cascades destroy to subsidiaries' do
+      it 'cascades to destroy the subsidiaries too' do
         subsidiary = firm.subsidiaries.first
         firm.destroy
         firm.run_callbacks(:commit)
         expect(Firm.where(id: subsidiary.id)).to be_empty
+      end
+    end
+
+    context 'when the firm has offices' do
+      let(:firm) { create(:firm_with_offices, offices_count: 1) }
+
+      it 'cascades to destroy the offices too' do
+        office = firm.offices.first
+        firm.destroy
+        firm.run_callbacks(:commit)
+        expect(Office.where(id: office.id)).to be_empty
       end
     end
 


### PR DESCRIPTION
Enhances the Firms -> Offices association to delete offices when the owning firm is deleted.