### PR TITLE
Refactor firm factory to use traits and tidy up the the firm_spec

### DIFF
--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -30,10 +30,8 @@ FactoryGirl.define do
     longitude { Faker::Address.longitude.to_f.round(6) }
     status :independent
 
-    factory :trading_name do
+    factory :trading_name, aliases: [:subsidiary] do
       parent factory: Firm
-
-      factory :subsidiary # alias for trading_name
     end
 
     factory :firm_with_advisers, traits: [:with_advisers]

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -30,18 +30,21 @@ FactoryGirl.define do
     longitude { Faker::Address.longitude.to_f.round(6) }
     status :independent
 
-    factory :firm_with_remote_advice do
-      other_advice_methods { create_list(:other_advice_method, rand(1..3)) }
-      in_person_advice_methods []
-    end
-
     factory :trading_name do
       parent factory: Firm
 
-      factory :subsidiary
+      factory :subsidiary # alias for trading_name
     end
 
-    factory :firm_with_no_business_split do
+    factory :firm_with_advisers, traits: [:with_advisers]
+    factory :firm_with_offices, traits: [:with_offices]
+    factory :firm_with_principal, traits: [:with_principal]
+    factory :firm_with_no_business_split, traits: [:with_no_business_split]
+    factory :firm_with_remote_advice, traits: [:with_remote_advice]
+    factory :firm_with_subsidiaries, traits: [:with_trading_names]
+    factory :firm_with_trading_names, traits: [:with_trading_names]
+
+    trait :with_no_business_split do
       retirement_income_products_flag false
       pension_transfer_flag false
       long_term_care_flag false
@@ -50,7 +53,7 @@ FactoryGirl.define do
       wills_and_probate_flag false
     end
 
-    factory :firm_with_advisers do
+    trait :with_advisers do
       transient do
         advisers_count 3
       end
@@ -60,13 +63,7 @@ FactoryGirl.define do
       end
     end
 
-    factory :firm_with_trading_names do
-      subsidiaries { create_list(:trading_name, 3, fca_number: fca_number) }
-
-      factory :firm_with_subsidiaries
-    end
-
-    factory :firm_with_principal do
+    trait :with_principal do
       principal { create(:principal) }
     end
 
@@ -80,6 +77,13 @@ FactoryGirl.define do
       end
     end
 
-    factory :firm_with_offices, traits: [:with_offices]
+    trait :with_remote_advice do
+      other_advice_methods { create_list(:other_advice_method, rand(1..3)) }
+      in_person_advice_methods []
+    end
+
+    trait :with_trading_names do
+      subsidiaries { create_list(:trading_name, 3, fca_number: fca_number) }
+    end
   end
 end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -455,14 +455,6 @@ RSpec.describe Firm do
         firm.destroy
         expect(Adviser.where(id: adviser.id)).to be_empty
       end
-
-      it 'does not geocode the firm' do
-        expect(GeocodeFirmJob).not_to receive(:perform_later)
-        adviser = firm.advisers.first
-        firm.destroy
-        firm.run_callbacks(:commit)
-        adviser.run_callbacks(:commit)
-      end
     end
 
     context 'when the firm has subsidiaries' do
@@ -496,10 +488,29 @@ RSpec.describe Firm do
     end
 
     describe 'deleting in elastic search' do
+      let(:firm) do
+        create(:firm,
+               :with_offices,
+               :with_advisers,
+               :with_principal,
+               offices_count: 1,
+               advisers_count: 1)
+      end
+
       context 'when the firm is destroyed' do
         it 'the firm is scheduled for deletion' do
           expect(DeleteFirmJob).to receive(:perform_later).with(firm.id)
           firm.destroy
+          firm.run_callbacks(:commit)
+        end
+
+        it 'does not trigger geocoding of the firm' do
+          expect(GeocodeFirmJob).not_to receive(:perform_later)
+          adviser = firm.advisers.first
+          office = firm.offices.first
+          firm.destroy
+          adviser.run_callbacks(:commit)
+          office.run_callbacks(:commit)
           firm.run_callbacks(:commit)
         end
       end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -453,8 +453,6 @@ RSpec.describe Firm do
       it 'cascades destroy to advisers' do
         adviser = firm.advisers.first
         firm.destroy
-        firm.run_callbacks(:commit)
-        adviser.run_callbacks(:commit)
         expect(Adviser.where(id: adviser.id)).to be_empty
       end
 
@@ -473,7 +471,6 @@ RSpec.describe Firm do
       it 'cascades to destroy the subsidiaries too' do
         subsidiary = firm.subsidiaries.first
         firm.destroy
-        firm.run_callbacks(:commit)
         expect(Firm.where(id: subsidiary.id)).to be_empty
       end
     end
@@ -484,7 +481,6 @@ RSpec.describe Firm do
       it 'cascades to destroy the offices too' do
         office = firm.offices.first
         firm.destroy
-        firm.run_callbacks(:commit)
         expect(Office.where(id: office.id)).to be_empty
       end
     end
@@ -495,7 +491,6 @@ RSpec.describe Firm do
       it 'does not destroy the principal' do
         principal = firm.principal
         firm.destroy
-        firm.run_callbacks(:commit)
         expect(Principal.where(token: principal.id)).not_to be_empty
       end
     end


### PR DESCRIPTION
It has reached a point where we really need to be able to combine traits when constructing Firms using FactoryGirl. Refactored the factory to make that possible. Tests ran against

* mas-rad_core
* rad (master)
* rad_consumer (dev/upgrade_mrc)

To ensure nothing has been broken.

Also tidied tests related to deleting firms to take out unnecessary calls to after_commit hooks etc. prompted by @JiggyPete's comment in #89.