### PR TITLE
[DEV APPROVED] Amend language list (add UK minority languages)

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -105,7 +105,7 @@ class Firm < ActiveRecord::Base
     presence: true
 
   validate :languages do
-    unless languages.all? { |lang| AVAILABLE_LANGUAGES_ISO_639_1_CODES.include?(lang) }
+    unless languages.all? { |lang| Languages::AVAILABLE_LANGUAGES_ISO_639_3_CODES.include?(lang) }
       errors.add(:languages, :invalid)
     end
   end
@@ -123,14 +123,6 @@ class Firm < ActiveRecord::Base
 
   after_commit :geocode, if: :valid?
   after_commit :delete_elastic_search_entry, if: :destroyed?
-
-  AVAILABLE_LANGUAGES = LanguageList::COMMON_LANGUAGES - [LanguageList::LanguageInfo.find('en')].freeze
-  AVAILABLE_LANGUAGES_ISO_639_1_CODES = Set.new(AVAILABLE_LANGUAGES.map(&:iso_639_1)).freeze
-
-  # Maintains existing interface
-  def self.available_languages
-    AVAILABLE_LANGUAGES
-  end
 
   def registered?
     email_address.present?

--- a/lib/mas/languages.rb
+++ b/lib/mas/languages.rb
@@ -1,0 +1,8 @@
+module Languages
+  UK_MINORITY_LANGUAGES = %w(sco gd bfi isg).map { |l| LanguageList::LanguageInfo.find l }
+  EXCLUDED_LANGUAGES = %w(en).map { |l| LanguageList::LanguageInfo.find l }
+  AVAILABLE_LANGUAGES = (
+    (LanguageList::COMMON_LANGUAGES + UK_MINORITY_LANGUAGES) - EXCLUDED_LANGUAGES
+  ).sort_by(&:common_name).freeze
+  AVAILABLE_LANGUAGES_ISO_639_3_CODES = Set.new(AVAILABLE_LANGUAGES.map(&:iso_639_3)).freeze
+end

--- a/spec/lib/mas/languages_spec.rb
+++ b/spec/lib/mas/languages_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Languages do
+  describe '::AVAILABLE_LANGUAGES' do
+    it 'returns a list of languages' do
+      expect(Languages::AVAILABLE_LANGUAGES).to have(74).languages
+    end
+
+    it 'does not include English' do
+      expect(Languages::AVAILABLE_LANGUAGES).to_not include LanguageList::LanguageInfo.find('en')
+    end
+
+    it 'does include minority languages' do
+      expect(Languages::AVAILABLE_LANGUAGES).to include LanguageList::LanguageInfo.find('sco')
+    end
+
+    it 'sorts them by common English name' do
+      sorted_languages = Languages::AVAILABLE_LANGUAGES.sort_by(&:common_name)
+      expect(Languages::AVAILABLE_LANGUAGES).to eq(sorted_languages)
+    end
+  end
+end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe Firm do
     end
   end
 
-  describe '.available_languages' do
-    it 'returns a list of common languages minus English' do
-      expect(Firm.available_languages).to eq(
-        LanguageList::COMMON_LANGUAGES - [LanguageList::LanguageInfo.find('en')]
-      )
-    end
-  end
-
   describe '#registered?' do
     it 'is false if the firm has no email address' do
       firm.email_address = nil
@@ -217,12 +209,12 @@ RSpec.describe Firm do
 
     describe 'languages' do
       context 'when it contains valid language strings' do
-        before { firm.languages = ['fr', 'de'] }
+        before { firm.languages = ['fra', 'deu'] }
         it { is_expected.to be_valid }
       end
 
       context 'when it contains invalid language strings' do
-        before { firm.languages = ['no_language', 'fr'] }
+        before { firm.languages = ['no_language', 'fra'] }
         it { is_expected.to be_invalid }
       end
 
@@ -240,10 +232,10 @@ RSpec.describe Firm do
       end
 
       context 'when it contains duplicate values' do
-        before { firm.languages = ['fr', 'fr', 'de'] }
+        before { firm.languages = ['fra', 'fra', 'deu'] }
         it 'filters them out pre-validation' do
           firm.valid?
-          expect(firm.languages).to eq ['fr', 'de']
+          expect(firm.languages).to eq ['fra', 'deu']
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] = 'test'
 require_relative 'dummy/config/environment'
 
 require 'rspec/rails'
+require 'rspec/collection_matchers'
 require 'factory_girl_rails'
 require 'faker'
 require 'pry'


### PR DESCRIPTION
Involved:

* Extracting languages to common module in lib.
* Using ISO 639-3 over 639-1 codes, since we now use some languages without ISO 639-1 codes.
* Remove `Firm.available_languages` since this is a convenient time to refer to it directly in RAD.