### PR TITLE
Add AdviserResult objects to a FirmResult

### DIFF
--- a/lib/mas/adviser_result.rb
+++ b/lib/mas/adviser_result.rb
@@ -1,0 +1,12 @@
+class AdviserResult
+  Location = Struct.new(:latitude, :longitude)
+
+  attr_reader :id, :name, :range, :location
+
+  def initialize(data)
+    @id       = data['_id']
+    @name     = data['name']
+    @range    = data['range']
+    @location = Location.new data['location']['lat'], data['location']['lon']
+  end
+end

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -39,6 +39,7 @@ class FirmResult
     source = data['_source']
     @id    = source['_id']
     @name  = source['registered_name']
+    @advisers         = source['advisers']
     @total_advisers   = source['advisers'].count
     @closest_adviser  = data['sort'].first
     @telephone_number = source['telephone_number']
@@ -46,6 +47,10 @@ class FirmResult
     (DIRECTLY_MAPPED_FIELDS + TYPES_OF_ADVICE_FIELDS).each do |field|
       instance_variable_set("@#{field}", source[field.to_s])
     end
+  end
+
+  def advisers
+    @advisers.map { |adviser_data| AdviserResult.new(adviser_data) }
   end
 
   def types_of_advice

--- a/spec/lib/mas/adviser_result_spec.rb
+++ b/spec/lib/mas/adviser_result_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe AdviserResult do
+  let(:data) {
+    {
+      '_id'      => 123,
+      'name'     => 'Mandy Advici',
+      'range'    => 50,
+      'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 }
+    }
+  }
+
+  subject { described_class.new(data) }
+
+  describe 'the deserialized adviser result' do
+    it 'maps id' do
+      expect(subject.id).to eq(123)
+    end
+
+    it 'maps the name' do
+      expect(subject.name).to eq('Mandy Advici')
+    end
+
+    it 'maps the range' do
+      expect(subject.range).to eq(50)
+    end
+
+    it 'maps the location with latitude and longitude' do
+      expect(subject.location.latitude).to eq(51.5180697)
+      expect(subject.location.longitude).to eq(-0.1085203)
+    end
+  end
+end

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe FirmResult do
       expect(subject.adviser_qualification_ids).to eq([3])
     end
 
+    describe '#advisers' do
+      it 'returns an array containing the advisers' do
+        expect(subject.advisers).to be_an(Array)
+        expect(subject.advisers.length).to eq(1)
+      end
+
+      it 'returns AdviserResult objects' do
+        expect(subject.advisers.first).to be_an(AdviserResult)
+      end
+    end
+
     describe '#minimum_pot_size?' do
       context 'when £50k or less' do
         it 'is false' do


### PR DESCRIPTION
When a search is retrieved from elastic search, it is transformed from a JSON result into a `SearchResult` object, which in turn has `FirmResult` objects. Each firm also has a collection of advisers, which are returned in the JSON, but currently not available via the ruby objects. This PR adds in an `AdviserResult` object and adds `FirmResult#advisers`