### PR TITLE
Update Offices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/dummy/tmp/
 spec/dummy/.sass-cache
 spec/dummy/config/*.yml
 bad_firms.csv
+*.todo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.74)
+    mas-rad_core (0.0.75)
       active_model_serializers
       geocoder
       httpclient

--- a/app/jobs/index_firm_job.rb
+++ b/app/jobs/index_firm_job.rb
@@ -4,6 +4,6 @@ class IndexFirmJob < ActiveJob::Base
   end
 
   def perform(firm)
-    FirmRepository.new.store(firm)
+    FirmRepository.new.store(firm) if firm.publishable?
   end
 end

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -31,7 +31,7 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
-  after_commit :geocode
+  after_commit :geocode_and_reindex_firm
   after_commit :reindex_old_firm, if: :firm_id_changed?
 
   scope :sorted_by_name, -> { order(:name) }
@@ -63,9 +63,9 @@ class Adviser < ActiveRecord::Base
 
   private
 
-  def geocode
+  def geocode_and_reindex_firm
     if destroyed?
-      firm.geocode
+      firm.geocode_and_reindex
     elsif valid?
       GeocodeAdviserJob.perform_later(self)
     end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -166,7 +166,7 @@ class Firm < ActiveRecord::Base
     ]
   end
 
-  def geocode
+  def geocode_and_reindex
     return if destroyed?
     GeocodeFirmJob.perform_later(self)
   end

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -34,7 +34,6 @@ class Firm < ActiveRecord::Base
   attr_accessor :percent_total
   attr_accessor :primary_advice_method
 
-  before_validation :upcase_postcode
   before_validation :clear_inapplicable_advice_methods,
                     if: -> { primary_advice_method == :remote }
   before_validation :clear_blank_languages
@@ -196,10 +195,6 @@ class Firm < ActiveRecord::Base
 
   def delete_elastic_search_entry
     DeleteFirmJob.perform_later(id)
-  end
-
-  def upcase_postcode
-    address_postcode.upcase! if address_postcode.present?
   end
 
   def infer_primary_advice_method

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -149,11 +149,6 @@ class Firm < ActiveRecord::Base
     [
       :email_address,
       :telephone_number,
-      :address_line_one,
-      :address_line_two,
-      :address_town,
-      :address_county,
-      :address_postcode,
       :in_person_advice_methods,
       :other_advice_methods,
       :free_initial_meeting,

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -112,11 +112,13 @@ class Firm < ActiveRecord::Base
   after_commit :geocode, if: :geocodable?
   after_commit :delete_elastic_search_entry, if: :destroyed?
 
+  # Maintains existing address interface
   delegate :address_line_one,
            :address_line_two,
            :address_town,
            :address_county,
            :address_postcode,
+           :full_street_address,
            to: :main_office,
            allow_nil: true
 
@@ -130,10 +132,6 @@ class Firm < ActiveRecord::Base
     return nil unless self[:telephone_number]
 
     self[:telephone_number].gsub(' ', '')
-  end
-
-  def full_street_address
-    [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
   end
 
   def in_person_advice?

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -179,6 +179,10 @@ class Firm < ActiveRecord::Base
     offices.first
   end
 
+  def publishable?
+    main_office.present?
+  end
+
   private
 
   def delete_elastic_search_entry

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -105,7 +105,12 @@ class Firm < ActiveRecord::Base
   validates :investment_sizes,
     length: { minimum: 1 }
 
+  after_save :publish_to_elastic_search
   after_commit :delete_elastic_search_entry, if: :destroyed?
+
+  def publish_to_elastic_search
+    IndexFirmJob.perform_later self
+  end
 
   # Maintains existing address interface
   delegate :address_line_one,

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -105,11 +105,6 @@ class Firm < ActiveRecord::Base
   validates :investment_sizes,
     length: { minimum: 1 }
 
-  def geocodable?
-    valid? && main_office.present?
-  end
-
-  after_commit :geocode, if: :geocodable?
   after_commit :delete_elastic_search_entry, if: :destroyed?
 
   # Maintains existing address interface

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -167,8 +167,7 @@ class Firm < ActiveRecord::Base
   end
 
   def geocode_and_reindex
-    return if destroyed?
-    GeocodeFirmJob.perform_later(self)
+    GeocodeFirmJob.perform_later(self) unless destroyed?
   end
 
   def advice_types

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,6 +1,8 @@
 class Office < ActiveRecord::Base
   belongs_to :firm
 
+  before_validation :upcase_postcode
+
   validates :email_address,
     presence: true,
     length: { maximum: 50 },
@@ -47,6 +49,12 @@ class Office < ActiveRecord::Base
 
   def telephone_number
     super.try { |x| x.gsub(' ', '') }
+  end
+
+  private
+
+  def upcase_postcode
+    address_postcode.upcase! if address_postcode.present?
   end
 end
 

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -51,6 +51,10 @@ class Office < ActiveRecord::Base
     super.try { |x| x.gsub(' ', '') }
   end
 
+  def full_street_address
+    [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
+  end
+
   private
 
   def upcase_postcode

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -34,7 +34,7 @@ class Office < ActiveRecord::Base
 
   validates :disabled_access, inclusion: { in: [true, false] }
 
-  after_commit :geocode
+  after_commit :geocode_and_reindex_firm
 
   def field_order
     [
@@ -63,10 +63,10 @@ class Office < ActiveRecord::Base
     address_postcode.upcase! if address_postcode.present?
   end
 
-  def geocode
+  def geocode_and_reindex_firm
     return if destroyed?
     if valid? and firm.try(:main_office) == self
-      firm.geocode # until we move the geocoding to offices, geocode the firm if this is the main office
+      firm.geocode_and_reindex # until we move the geocoding to offices, geocode the firm if this is the main office
     end
   end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -34,6 +34,8 @@ class Office < ActiveRecord::Base
 
   validates :disabled_access, inclusion: { in: [true, false] }
 
+  after_commit :geocode
+
   def field_order
     [
       :address_line_one,
@@ -59,6 +61,13 @@ class Office < ActiveRecord::Base
 
   def upcase_postcode
     address_postcode.upcase! if address_postcode.present?
+  end
+
+  def geocode
+    return if destroyed?
+    if valid? and firm.try(:main_office) == self
+      firm.geocode # until we move the geocoding to offices, geocode the firm if this is the main office
+    end
   end
 end
 

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -4,12 +4,12 @@ class Office < ActiveRecord::Base
   before_validation :upcase_postcode
 
   validates :email_address,
-    presence: true,
+    presence: false,
     length: { maximum: 50 },
     format: { with: /.+@.+\..+/ }
 
   validates :telephone_number,
-    presence: true,
+    presence: false,
     length: { maximum: 30 },
     format: { with: /\A[0-9 ]+\z/ }
 
@@ -29,7 +29,7 @@ class Office < ActiveRecord::Base
     length: { maximum: 100 }
 
   validates :address_county,
-    presence: true,
+    presence: false,
     length: { maximum: 100 }
 
   validates :disabled_access, inclusion: { in: [true, false] }

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -65,9 +65,13 @@ class Office < ActiveRecord::Base
 
   def geocode_and_reindex_firm
     return if destroyed?
-    if valid? and firm.try(:main_office) == self
+    if valid? and main_office?
       firm.geocode_and_reindex # until we move the geocoding to offices, geocode the firm if this is the main office
     end
+  end
+
+  def main_office?
+    firm.try(:main_office) == self
   end
 end
 

--- a/db/migrate/20150825090822_move_firm_address_to_office.rb
+++ b/db/migrate/20150825090822_move_firm_address_to_office.rb
@@ -1,0 +1,48 @@
+# Moving address to a main office. Please note that email and telephone number
+# are remaining on Firm, however we seed the main office with the firm's
+# email address and telephone number to start with.
+class MoveFirmAddressToOffice < ActiveRecord::Migration
+  class Firm < ActiveRecord::Base; has_many :offices; end
+  class Office < ActiveRecord::Base; belongs_to :firm; end
+
+  def up
+    Firm.where.not(address_line_one: nil) do |firm|
+      next if firm.offices.any?
+
+      firm.offices.create!(
+        address_line_one: firm.address_line_one,
+        address_line_two: firm.address_line_two,
+        address_town: firm.address_town,
+        address_county: firm.address_county,
+        address_postcode: firm.address_postcode,
+        email_address: firm.email_address,
+        telephone_number: firm.telephone_number
+      )
+    end
+
+    remove_column :firms, :address_line_one
+    remove_column :firms, :address_line_two
+    remove_column :firms, :address_town
+    remove_column :firms, :address_county
+    remove_column :firms, :address_postcode
+  end
+
+  def down
+    add_column :firms, :address_line_one, :string
+    add_column :firms, :address_line_two, :string
+    add_column :firms, :address_town,     :string
+    add_column :firms, :address_county,   :string
+    add_column :firms, :address_postcode, :string
+
+    Firm.all.select { |f| f.offices.any? }.each do |firm|
+      main_office = firm.offices.first
+      firm.update!(
+        address_line_one: main_office.address_line_one,
+        address_line_two: main_office.address_line_two,
+        address_town: main_office.address_town,
+        address_county: main_office.address_county,
+        address_postcode: main_office.address_postcode
+      )
+    end
+  end
+end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.74'
+    VERSION = '0.0.75'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150817141257) do
+ActiveRecord::Schema.define(version: 20150825090822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,11 +84,6 @@ ActiveRecord::Schema.define(version: 20150817141257) do
     t.string   "telephone_number"
     t.datetime "created_at",                                               null: false
     t.datetime "updated_at",                                               null: false
-    t.string   "address_line_one"
-    t.string   "address_line_two"
-    t.string   "address_town"
-    t.string   "address_county"
-    t.string   "address_postcode"
     t.boolean  "free_initial_meeting"
     t.integer  "initial_meeting_duration_id"
     t.integer  "minimum_fixed_fee"
@@ -104,8 +99,8 @@ ActiveRecord::Schema.define(version: 20150817141257) do
     t.string   "website_address"
     t.boolean  "ethical_investing_flag",                   default: false, null: false
     t.boolean  "sharia_investing_flag",                    default: false, null: false
-    t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
+    t.text     "languages",                                default: [],    null: false, array: true
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -7,11 +7,6 @@ FactoryGirl.define do
     email_address { Faker::Internet.email }
     telephone_number { Faker::Base.numerify('##### ### ###') }
     website_address { Faker::Internet.url }
-    address_line_one { Faker::Address.street_address }
-    address_line_two { Faker::Address.secondary_address }
-    address_town { Faker::Address.city }
-    address_county { Faker::Address.state }
-    address_postcode 'EC1N 2TD'
     in_person_advice_methods { create_list(:in_person_advice_method, rand(1..3)) }
     free_initial_meeting { [true, false].sample }
     initial_meeting_duration { create(:initial_meeting_duration) }

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -72,6 +72,7 @@ FactoryGirl.define do
 
       after(:create) do |firm, evaluator|
         create_list(:office, evaluator.offices_count, firm: firm)
+        firm.reload
       end
     end
 

--- a/spec/jobs/geocode_adviser_job_spec.rb
+++ b/spec/jobs/geocode_adviser_job_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GeocodeAdviserJob do
   let(:job) { GeocodeAdviserJob.new }
 
-  subject(:adviser) { create(:adviser, postcode: postcode) }
+  let!(:adviser) { create(:adviser, postcode: postcode) }
 
   describe '#perform' do
     context 'when the adviser postcode can be geocoded' do

--- a/spec/jobs/geocode_firm_job_spec.rb
+++ b/spec/jobs/geocode_firm_job_spec.rb
@@ -3,12 +3,14 @@ require 'geocoder'
 RSpec.describe GeocodeFirmJob do
   let(:job) { GeocodeFirmJob.new }
 
-  subject(:firm) do
-    create(:firm,
-      address_line_one: address_line_one,
-      address_line_two: address_line_two,
-      address_postcode: address_postcode
-    )
+  subject(:firm) { create(:firm) }
+
+  before do
+    create(:office, firm: firm,
+                    address_line_one: address_line_one,
+                    address_line_two: address_line_two,
+                    address_postcode: address_postcode)
+    firm.reload
   end
 
   describe '#perform' do

--- a/spec/jobs/index_firm_job_spec.rb
+++ b/spec/jobs/index_firm_job_spec.rb
@@ -1,14 +1,30 @@
 RSpec.describe IndexFirmJob, '#perform' do
-  let(:firm) { create(:adviser).firm }
   let(:repository) { instance_double(FirmRepository) }
+  let(:firm) { Firm.new }
 
   before do
     allow(FirmRepository).to receive(:new).and_return(repository)
   end
 
-  it 'delegates to the firm repository' do
-    expect(repository).to receive(:store).with(firm)
+  context 'when firm is publishable' do
+    before do
+      allow(firm).to receive(:publishable?).and_return(true)
+    end
 
-    described_class.new.perform(firm)
+    it 'delegates to the firm repository' do
+      expect(repository).to receive(:store).with(firm)
+      described_class.new.perform(firm)
+    end
+  end
+
+  context 'when firm is not publishable' do
+    before do
+      allow(firm).to receive(:publishable?).and_return(false)
+    end
+
+    it 'does not delegates to the firm repository' do
+      expect(repository).not_to receive(:store).with(firm)
+      described_class.new.perform(firm)
+    end
   end
 end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -1,16 +1,8 @@
 RSpec.describe Adviser do
+  include QueueSpecHelper
+
   before do
     clear_job_queue
-  end
-
-  def clear_job_queue
-    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
-  end
-
-  def queue_contains_a_job_for(job_class)
-    ActiveJob::Base.queue_adapter.enqueued_jobs.any? do |elem|
-      elem[:job] == job_class
-    end
   end
 
   describe '#geocoded?' do

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Adviser do
     let(:job_class) { GeocodeAdviserJob }
   end
 
-  describe 'after_commit :geocode' do
+  describe 'after_commit :geocode_and_reindex' do
     let(:adviser) { create(:adviser) }
 
     context 'when the postcode is present' do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -356,25 +356,6 @@ RSpec.describe Firm do
     end
   end
 
-  describe '#full_street_address' do
-    let(:firm) { FactoryGirl.create(:firm_with_offices, offices_count: 1) }
-    subject { firm.full_street_address }
-
-    it { is_expected.to eql "#{firm.address_line_one}, #{firm.address_line_two}, #{firm.address_postcode}, United Kingdom"}
-
-    context 'when line two is nil' do
-      before { firm.main_office.update!(address_line_two: nil) }
-
-      it { is_expected.to eql "#{firm.address_line_one}, #{firm.address_postcode}, United Kingdom"}
-    end
-
-    context 'when line two is an empty string' do
-      before { firm.main_office.update!(address_line_two: '') }
-
-      it { is_expected.to eql "#{firm.address_line_one}, #{firm.address_postcode}, United Kingdom"}
-    end
-  end
-
   it_should_behave_like 'geocodable' do
     subject(:firm) { create(:firm) }
     let(:job_class) { GeocodeFirmJob }

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -374,6 +374,34 @@ RSpec.describe Firm do
     let(:job_class) { GeocodeFirmJob }
   end
 
+  describe 'after_commit:publish_firm' do
+    context 'when a firm is created' do
+      it 'the firm is published' do
+        allow(IndexFirmJob).to receive(:perform_later)
+        firm = create :firm
+        expect(IndexFirmJob).to have_received(:perform_later).with(firm)
+      end
+    end
+
+    context 'when a firm is updated' do
+      it 'the firm is published' do
+        firm = create :firm
+        allow(IndexFirmJob).to receive(:perform_later)
+        firm.update_attributes(email_address: 'bill@example.com')
+        expect(IndexFirmJob).to have_received(:perform_later).with(firm)
+      end
+    end
+
+    context 'when a firm is destroyed' do
+      it 'the firm is not published' do
+        firm = create :firm
+        allow(IndexFirmJob).to receive(:perform_later)
+        firm.destroy
+        expect(IndexFirmJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+
   describe 'destroying' do
     context 'when the firm has advisers' do
       let(:firm) { create(:firm_with_advisers) }

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -374,6 +374,21 @@ RSpec.describe Firm do
     let(:job_class) { GeocodeFirmJob }
   end
 
+  describe '#geocode_and_reindex' do
+    # does the reindexing inside the GeocodeFirmJob, tests for that are there
+
+    it 'performs a geocode firm job' do
+      firm.geocode_and_reindex
+      expect(GeocodeFirmJob).to have_received(:perform_later).with(firm)
+    end
+
+    it 'does not perform a geocode firm job when the firm has been destroyed' do
+      firm.destroy
+      firm.geocode_and_reindex
+      expect(GeocodeFirmJob).not_to have_received(:perform_later).with(firm)
+    end
+  end
+
   describe 'after_commit:publish_firm' do
     context 'when a firm is created' do
       it 'the firm is published' do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Firm do
     end
 
     describe 'default sort order' do
-      subject { firm.offices.map(&:address_line_one) }
+      subject { firm.reload.offices.map(&:address_line_one) }
       it { is_expected.to eq(%w{first second third fourth}) }
     end
   end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe Firm do
     end
   end
 
+  describe '#publishable?' do
+    subject { create(:firm) }
+
+    context 'when the firm has no main office' do
+      it { expect(subject).not_to be_publishable }
+    end
+
+    context 'when the firm has a main office' do
+      before { FactoryGirl.create(:office, firm: subject) }
+      it { expect(subject).to be_publishable }
+    end
+  end
+
   describe 'validation' do
     it 'is valid with valid attributes' do
       expect(firm).to be_valid

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -361,62 +361,6 @@ RSpec.describe Firm do
     let(:job_class) { GeocodeFirmJob }
   end
 
-  describe '#geocodable?' do
-    context 'when the firm is not valid' do
-      before { firm.email_address = nil }
-
-      it 'is not geocodable' do
-        expect(firm).not_to be_geocodable
-      end
-    end
-
-    context 'when the firm is valid' do
-      context 'but it does not have a main office' do
-        before { expect(firm.offices.any?).to be_falsey }
-
-        it 'is not geocodable' do
-          expect(firm).not_to be_geocodable
-        end
-      end
-
-      context 'and it has a main office' do
-        let(:office) { FactoryGirl.build(:office) }
-
-        before do
-          allow(firm).to receive(:main_office).and_return(office)
-        end
-
-        it 'is geocodable' do
-          expect(firm).to be_geocodable
-        end
-      end
-    end
-  end
-
-  describe 'geocoding' do
-    before :each do
-      allow(firm).to receive(:geocodable?) { geocodable }
-      allow(GeocodeFirmJob).to receive(:perform_later)
-      firm.run_callbacks(:commit)
-    end
-
-    context 'when the firm is geocodable' do
-      let(:geocodable) { true }
-
-      it 'the firm is scheduled for geocoding' do
-        expect(GeocodeFirmJob).to have_received(:perform_later).with(firm)
-      end
-    end
-
-    context 'when the firm is not geocodable' do
-      let(:geocodable) { false }
-
-      it 'the firm is not scheduled for geocoding' do
-        expect(GeocodeFirmJob).not_to have_received(:perform_later)
-      end
-    end
-  end
-
   describe 'destroying' do
     context 'when the firm has advisers' do
       let(:firm) { create(:firm_with_advisers) }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -150,4 +150,24 @@ RSpec.describe Office do
       end
     end
   end
+
+  describe '#full_street_address' do
+    let(:office) { FactoryGirl.build(:office) }
+
+    subject { office.full_street_address }
+
+    it { is_expected.to eql "#{office.address_line_one}, #{office.address_line_two}, #{office.address_postcode}, United Kingdom"}
+
+    context 'when line two is nil' do
+      before { office.address_line_two = nil }
+
+      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
+    end
+
+    context 'when line two is an empty string' do
+      before { office.address_line_two = '' }
+
+      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
+    end
+  end
 end

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Office do
 
   subject(:office) { FactoryGirl.build(:office, firm: firm) }
 
-  describe 'after_commit :geocode' do
+  describe 'after_commit :geocode_and_reindex_firm' do
     let(:firm) { FactoryGirl.build(:firm, id: 123) }
 
     before do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Office do
       context 'when missing' do
         before { office.address_county = nil }
 
-        it { is_expected.not_to be_valid }
+        it { is_expected.to be_valid }
       end
 
       context 'length' do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -1,7 +1,48 @@
 RSpec.describe Office do
   include FieldLengthValidationHelpers
 
-  subject(:office) { FactoryGirl.build(:office) }
+  let(:firm) { nil }
+
+  subject(:office) { FactoryGirl.build(:office, firm: firm) }
+
+  describe 'after_commit :geocode' do
+    let(:firm) { FactoryGirl.build(:firm, id: 123) }
+
+    before do
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
+    context 'when the address_postcode is not valid' do
+      before { office.address_postcode = nil }
+
+      it 'does not schedule the firm for geocoding' do
+        expect { office.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
+      end
+    end
+
+    context 'when the address_postcode is valid' do
+      context 'but the office is not the main office for the firm' do
+        it 'does not schedule the firm for geocoding' do
+          expect { office.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
+        end
+      end
+
+      context 'and the office is the main office for the firm' do
+        before { allow(firm).to receive(:main_office).and_return(office) }
+
+        it 'schedules the firm for geocoding' do
+          expect { office.run_callbacks(:commit) }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
+        end
+
+        context 'when the office has been destroyed' do
+          it 'does not schedule the firm for geocoding' do
+            office.destroy
+            expect { office.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
+          end
+        end
+      end
+    end
+  end
 
   describe '#telephone_number' do
     context 'when `nil`' do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -119,6 +119,15 @@ RSpec.describe Office do
 
         it { is_expected.not_to be_valid }
       end
+
+      context 'when not all upper cased' do
+        before { office.address_postcode.downcase! }
+
+        it 'upcases it before validating' do
+          expect(office).to be_valid
+          expect(office.address_postcode).to eq(office.address_postcode.upcase)
+        end
+      end
     end
 
     describe 'disabled access' do

--- a/spec/support/queue_spec_helper.rb
+++ b/spec/support/queue_spec_helper.rb
@@ -1,0 +1,11 @@
+module QueueSpecHelper
+  def clear_job_queue
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+  end
+
+  def queue_contains_a_job_for(job_class)
+    ActiveJob::Base.queue_adapter.enqueued_jobs.any? do |elem|
+      elem[:job] == job_class
+    end
+  end
+end


### PR DESCRIPTION
This PR is to migrate the address fields out of `firm.rb` and into `office.rb`.

FYI a firm can have multiple offices.

Along the way we also renamed after_commit hooks from `.geocode` to `.geocode_and_reindex` to more clearly explain what the method does.