### PR TITLE
Fix the firm factory and add a confidence test

### DIFF
--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -25,11 +25,12 @@ FactoryGirl.define do
     longitude { Faker::Address.longitude.to_f.round(6) }
     status :independent
 
-    factory :onboarded_firm
-
-    factory :not_onboarded_firm do
-      email_address nil
+    factory :onboarded_firm, traits: [:with_advisers, :with_offices], aliases: [:publishable_firm] do
+      advisers_count 1
+      offices_count 1
     end
+
+    factory :not_onboarded_firm, traits: [:invalid]
 
     factory :trading_name, aliases: [:subsidiary] do
       parent factory: Firm
@@ -42,6 +43,11 @@ FactoryGirl.define do
     factory :firm_with_remote_advice, traits: [:with_remote_advice]
     factory :firm_with_subsidiaries, traits: [:with_trading_names]
     factory :firm_with_trading_names, traits: [:with_trading_names]
+    factory :invalid_firm, traits: [:invalid]
+
+    trait :invalid do
+      email_address nil
+    end
 
     trait :with_no_business_split do
       retirement_income_products_flag false

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -25,12 +25,9 @@ FactoryGirl.define do
     longitude { Faker::Address.longitude.to_f.round(6) }
     status :independent
 
-    factory :onboarded_firm do
-      parent factory: Firm
-    end
+    factory :onboarded_firm
 
     factory :not_onboarded_firm do
-      parent factory: Firm
       email_address nil
     end
 

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Firm factory' do
       it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
+      it { is_expected.to have(:no).trading_names }
     end
   end
 
@@ -38,6 +39,7 @@ RSpec.describe 'Firm factory' do
       it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(1).offices }
       it { is_expected.to have(1).advisers }
+      it { is_expected.to have(:no).trading_names }
     end
   end
 
@@ -55,6 +57,7 @@ RSpec.describe 'Firm factory' do
       it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
+      it { is_expected.to have(:no).trading_names }
     end
   end
 
@@ -75,6 +78,7 @@ RSpec.describe 'Firm factory' do
 
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
+      it { is_expected.to have(:no).trading_names }
     end
   end
 
@@ -92,6 +96,7 @@ RSpec.describe 'Firm factory' do
       it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
+      it { is_expected.to have(:no).trading_names }
     end
   end
 end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -61,6 +61,63 @@ RSpec.describe 'Firm factory' do
     end
   end
 
+  describe 'factory :firm_with_advisers' do
+    let(:factory) { :firm_with_advisers }
+
+    context 'expected status' do
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { expect(subject.principal).not_to be_present }
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(3).advisers }
+      it { is_expected.to have(:no).trading_names }
+    end
+  end
+
+  describe 'factory :firm_with_offices' do
+    let(:factory) { :firm_with_offices }
+
+    context 'expected status' do
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { expect(subject.principal).not_to be_present }
+      it { is_expected.to have(3).offices }
+      it { is_expected.to have(:no).advisers }
+      it { is_expected.to have(:no).trading_names }
+    end
+  end
+
+  describe 'factory :firm_with_trading_names' do
+    let(:factory) { :firm_with_trading_names }
+
+    context 'expected status' do
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { expect(subject.principal).not_to be_present }
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(:no).advisers }
+
+      it { is_expected.to have(3).trading_names }
+      it { expect(subject.trading_names).to all(have_attributes(fca_number: subject.fca_number))}
+      it { expect(subject.trading_names).to all(have_attributes(parent: subject))}
+    end
+  end
+
   describe 'factory :firm_with_principal' do
     let(:factory) { :firm_with_principal }
 

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -58,23 +58,6 @@ RSpec.describe 'Firm factory' do
     end
   end
 
-  describe 'factory :invalid_firm' do
-    let(:factory) { :invalid_firm }
-
-    context 'expected status' do
-      it { is_expected.not_to be_persisted }
-      it { is_expected.not_to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
-    end
-
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(:no).advisers }
-    end
-  end
-
   describe 'factory :firm_with_principal' do
     let(:factory) { :firm_with_principal }
 
@@ -90,6 +73,23 @@ RSpec.describe 'Firm factory' do
       it { expect(subject.principal.fca_number).to eq(subject.fca_number) }
       # it { expect(subject.principal.firm).to eq(subject) } # @todo fails. Creates principal with 2 main firms !!!
 
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(:no).advisers }
+    end
+  end
+
+  describe 'factory :invalid_firm' do
+    let(:factory) { :invalid_firm }
+
+    context 'expected status' do
+      it { is_expected.not_to be_persisted }
+      it { is_expected.not_to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
     end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).to be_valid
       expect(subject).not_to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -33,6 +34,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).to be_valid
       expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -51,6 +53,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).not_to be_valid
       expect(subject).not_to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -69,6 +72,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).to be_valid
       expect(subject).not_to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -87,6 +91,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).to be_valid
       expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -105,6 +110,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).to be_valid
       expect(subject).not_to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -126,6 +132,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).to be_valid
       expect(subject).not_to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
@@ -147,6 +154,7 @@ RSpec.describe 'Firm factory' do
       expect(subject).not_to be_valid
       expect(subject).not_to be_publishable
       expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe 'Firm factory' do
+  def create_invalid(factory)
+    FactoryGirl.build(factory).tap { |f| f.save(validation: false) }
+  end
+
+  subject { FactoryGirl.create(factory) }
+
+  describe 'factory :firm (default factory)' do
+    let(:factory) { :firm }
+
+    context 'expected status' do
+      it { is_expected.to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(:no).advisers }
+    end
+  end
+
+  describe 'factory :onboarded_firm' do
+    let(:factory) { :onboarded_firm }
+
+    context 'expected status' do
+      it { is_expected.to be_valid }
+      it { is_expected.to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { is_expected.to have(1).offices }
+      it { is_expected.to have(1).advisers }
+    end
+  end
+
+  describe 'factory :not_onboarded_firm' do
+    let(:factory) { :not_onboarded_firm }
+    subject { create_invalid(factory) }
+
+    context 'expected status' do
+      it { is_expected.not_to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(:no).advisers }
+    end
+  end
+
+  describe 'factory :invalid_firm' do
+    let(:factory) { :invalid_firm }
+    subject { create_invalid(factory) }
+
+    context 'expected status' do
+      it { is_expected.not_to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(:no).advisers }
+    end
+  end
+end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -1,14 +1,17 @@
 RSpec.describe 'Firm factory' do
-  def create_invalid(factory)
-    FactoryGirl.build(factory).tap { |f| f.save(validation: false) }
+  subject do
+    begin
+      FactoryGirl.create(factory)
+    rescue ActiveRecord::RecordInvalid
+      FactoryGirl.build(factory)
+    end
   end
-
-  subject { FactoryGirl.create(factory) }
 
   describe 'factory :firm (default factory)' do
     let(:factory) { :firm }
 
     context 'expected status' do
+      it { is_expected.to be_persisted }
       it { is_expected.to be_valid }
       it { is_expected.not_to be_publishable }
       it { is_expected.not_to be_trading_name }
@@ -24,6 +27,7 @@ RSpec.describe 'Firm factory' do
     let(:factory) { :onboarded_firm }
 
     context 'expected status' do
+      it { is_expected.to be_persisted }
       it { is_expected.to be_valid }
       it { is_expected.to be_publishable }
       it { is_expected.not_to be_trading_name }
@@ -37,9 +41,9 @@ RSpec.describe 'Firm factory' do
 
   describe 'factory :not_onboarded_firm' do
     let(:factory) { :not_onboarded_firm }
-    subject { create_invalid(factory) }
 
     context 'expected status' do
+      it { is_expected.not_to be_persisted }
       it { is_expected.not_to be_valid }
       it { is_expected.not_to be_publishable }
       it { is_expected.not_to be_trading_name }
@@ -53,9 +57,9 @@ RSpec.describe 'Firm factory' do
 
   describe 'factory :invalid_firm' do
     let(:factory) { :invalid_firm }
-    subject { create_invalid(factory) }
 
     context 'expected status' do
+      it { is_expected.not_to be_persisted }
       it { is_expected.not_to be_valid }
       it { is_expected.not_to be_publishable }
       it { is_expected.not_to be_trading_name }

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Firm factory' do
     end
 
     context 'associations' do
+      it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
     end
@@ -34,6 +35,7 @@ RSpec.describe 'Firm factory' do
     end
 
     context 'associations' do
+      it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(1).offices }
       it { is_expected.to have(1).advisers }
     end
@@ -50,6 +52,7 @@ RSpec.describe 'Firm factory' do
     end
 
     context 'associations' do
+      it { expect(subject.principal).not_to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
     end
@@ -66,6 +69,24 @@ RSpec.describe 'Firm factory' do
     end
 
     context 'associations' do
+      it { expect(subject.principal).not_to be_present }
+      it { is_expected.to have(:no).offices }
+      it { is_expected.to have(:no).advisers }
+    end
+  end
+
+  describe 'factory :firm_with_principal' do
+    let(:factory) { :firm_with_principal }
+
+    context 'expected status' do
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.not_to be_publishable }
+      it { is_expected.not_to be_trading_name }
+    end
+
+    context 'associations' do
+      it { expect(subject.principal).to be_present }
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
     end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -87,6 +87,9 @@ RSpec.describe 'Firm factory' do
 
     context 'associations' do
       it { expect(subject.principal).to be_present }
+      it { expect(subject.principal.fca_number).to eq(subject.fca_number) }
+      # it { expect(subject.principal.firm).to eq(subject) } # @todo fails. Creates principal with 2 main firms !!!
+
       it { is_expected.to have(:no).offices }
       it { is_expected.to have(:no).advisers }
     end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -146,6 +146,25 @@ RSpec.describe 'Firm factory' do
     end
   end
 
+  describe 'factory :firm_with_remote_advice' do
+    let(:factory) { :firm_with_remote_advice }
+
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:remote)
+    end
+
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(:no).offices
+      expect(subject).to have(:no).advisers
+      expect(subject).to have(:no).trading_names
+    end
+  end
+
   describe 'factory :invalid_firm' do
     let(:factory) { :invalid_firm }
 

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe 'Firm factory' do
     begin
       FactoryGirl.create(factory)
     rescue ActiveRecord::RecordInvalid
+      # If create fails we fall back to a build. We can then explicitly test
+      # what we expect to have happened using the `be_persisted` matcher.
       FactoryGirl.build(factory)
     end
   end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -10,150 +10,150 @@ RSpec.describe 'Firm factory' do
   describe 'factory :firm (default factory)' do
     let(:factory) { :firm }
 
-    context 'expected status' do
-      it { is_expected.to be_persisted }
-      it { is_expected.to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(:no).advisers }
-      it { is_expected.to have(:no).trading_names }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(:no).offices
+      expect(subject).to have(:no).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 
   describe 'factory :onboarded_firm' do
     let(:factory) { :onboarded_firm }
 
-    context 'expected status' do
-      it { is_expected.to be_persisted }
-      it { is_expected.to be_valid }
-      it { is_expected.to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(1).offices }
-      it { is_expected.to have(1).advisers }
-      it { is_expected.to have(:no).trading_names }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(1).offices
+      expect(subject).to have(1).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 
   describe 'factory :not_onboarded_firm' do
     let(:factory) { :not_onboarded_firm }
 
-    context 'expected status' do
-      it { is_expected.not_to be_persisted }
-      it { is_expected.not_to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).not_to be_persisted
+      expect(subject).not_to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(:no).advisers }
-      it { is_expected.to have(:no).trading_names }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(:no).offices
+      expect(subject).to have(:no).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 
   describe 'factory :firm_with_advisers' do
     let(:factory) { :firm_with_advisers }
 
-    context 'expected status' do
-      it { is_expected.to be_persisted }
-      it { is_expected.to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(3).advisers }
-      it { is_expected.to have(:no).trading_names }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(:no).offices
+      expect(subject).to have(3).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 
   describe 'factory :firm_with_offices' do
     let(:factory) { :firm_with_offices }
 
-    context 'expected status' do
-      it { is_expected.to be_persisted }
-      it { is_expected.to be_valid }
-      it { is_expected.to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(3).offices }
-      it { is_expected.to have(:no).advisers }
-      it { is_expected.to have(:no).trading_names }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(3).offices
+      expect(subject).to have(:no).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 
   describe 'factory :firm_with_trading_names' do
     let(:factory) { :firm_with_trading_names }
 
-    context 'expected status' do
-      it { is_expected.to be_persisted }
-      it { is_expected.to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(:no).advisers }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(:no).offices
+      expect(subject).to have(:no).advisers
 
-      it { is_expected.to have(3).trading_names }
-      it { expect(subject.trading_names).to all(have_attributes(fca_number: subject.fca_number))}
-      it { expect(subject.trading_names).to all(have_attributes(parent: subject))}
+      expect(subject).to have(3).trading_names
+      expect(subject.trading_names).to all(have_attributes(fca_number: subject.fca_number))
+      expect(subject.trading_names).to all(have_attributes(parent: subject))
     end
   end
 
   describe 'factory :firm_with_principal' do
     let(:factory) { :firm_with_principal }
 
-    context 'expected status' do
-      it { is_expected.to be_persisted }
-      it { is_expected.to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).to be_present }
-      it { expect(subject.principal.fca_number).to eq(subject.fca_number) }
-      # it { expect(subject.principal.firm).to eq(subject) } # @todo fails. Creates principal with 2 main firms !!!
+    specify 'associations' do
+      expect(subject.principal).to be_present
+      expect(subject.principal.fca_number).to eq(subject.fca_number)
+      # expect(subject.principal.firm).to eq(subject) # @todo fails. Creates principal with 2 main firms !!!
 
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(:no).advisers }
-      it { is_expected.to have(:no).trading_names }
+      expect(subject).to have(:no).offices
+      expect(subject).to have(:no).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 
   describe 'factory :invalid_firm' do
     let(:factory) { :invalid_firm }
 
-    context 'expected status' do
-      it { is_expected.not_to be_persisted }
-      it { is_expected.not_to be_valid }
-      it { is_expected.not_to be_publishable }
-      it { is_expected.not_to be_trading_name }
+    specify 'expected status' do
+      expect(subject).not_to be_persisted
+      expect(subject).not_to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
     end
 
-    context 'associations' do
-      it { expect(subject.principal).not_to be_present }
-      it { is_expected.to have(:no).offices }
-      it { is_expected.to have(:no).advisers }
-      it { is_expected.to have(:no).trading_names }
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(:no).offices
+      expect(subject).to have(:no).advisers
+      expect(subject).to have(:no).trading_names
     end
   end
 end

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -138,7 +138,10 @@ RSpec.describe 'Firm factory' do
     specify 'associations' do
       expect(subject.principal).to be_present
       expect(subject.principal.fca_number).to eq(subject.fca_number)
-      # expect(subject.principal.firm).to eq(subject) # @todo fails. Creates principal with 2 main firms !!!
+      # @todo fails. Creates principal with 2 main firms !!!
+      # Note: we need to wait until rad_consumer is updated to run with the latest version of this Gem
+      # so that we can check that nothing gets broken by fixing this
+      # expect(subject.principal.firm).to eq(subject)
 
       expect(subject).to have(:no).offices
       expect(subject).to have(:no).advisers


### PR DESCRIPTION
Following the "3 strikes and you're out rule", I felt it was time to do something about this firm factory: several times now we have discovered that the factories are not producing valid fixtures, in which case how can we trust our tests?

# Goals

1. Correct the factory definitions that do not produce valid models
2. Think of a way to sanity check the factories going forward

# Outstanding work

I decided not to fix the `:firm_with_principal` fixture at this point. We need to upgrade the `rad_consumer` project from using 0.0.74 of `mas-rad_core` to 0.0.78, there are a lot of broken tests there right now I don't want to add to that work until we can see the size of it clearly (this upgrade is my actual task, I just wanted to sort this out and PR it first)