### PR TITLE
Modify :firm factory so it creates publishable Firms by default

### DIFF
--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   sequence(:registered_name) { |n| "Financial Advice #{n} Ltd." }
 
-  factory :firm do
+  factory :firm, aliases: [:publishable_firm] do
     fca_number
     registered_name
     email_address { Faker::Internet.email }
@@ -25,9 +25,17 @@ FactoryGirl.define do
     longitude { Faker::Address.longitude.to_f.round(6) }
     status :independent
 
-    factory :onboarded_firm, traits: [:with_advisers, :with_offices], aliases: [:publishable_firm] do
-      advisers_count 1
+    transient do
       offices_count 1
+    end
+
+    after(:create) do |firm, evaluator|
+      create_list(:office, evaluator.offices_count, firm: firm)
+      firm.reload
+    end
+
+    factory :onboarded_firm, traits: [:with_advisers] do
+      advisers_count 1
     end
 
     factory :not_onboarded_firm, traits: [:invalid]
@@ -73,14 +81,7 @@ FactoryGirl.define do
     end
 
     trait :with_offices do
-      transient do
-        offices_count 3
-      end
-
-      after(:create) do |firm, evaluator|
-        create_list(:office, evaluator.offices_count, firm: firm)
-        firm.reload
-      end
+      offices_count 3
     end
 
     trait :with_remote_advice do

--- a/spec/jobs/geocode_firm_job_spec.rb
+++ b/spec/jobs/geocode_firm_job_spec.rb
@@ -6,10 +6,9 @@ RSpec.describe GeocodeFirmJob do
   subject(:firm) { create(:firm) }
 
   before do
-    create(:office, firm: firm,
-                    address_line_one: address_line_one,
-                    address_line_two: address_line_two,
-                    address_postcode: address_postcode)
+    firm.main_office.update!(address_line_one: address_line_one,
+                             address_line_two: address_line_two,
+                             address_postcode: address_postcode)
     firm.reload
   end
 

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe 'Firm factory' do
     specify 'expected status' do
       expect(subject).to be_persisted
       expect(subject).to be_valid
-      expect(subject).not_to be_publishable
+      expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
       expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
       expect(subject.principal).not_to be_present
-      expect(subject).to have(:no).offices
+      expect(subject).to have(1).offices
       expect(subject).to have(:no).advisers
       expect(subject).to have(:no).trading_names
     end
@@ -72,14 +72,14 @@ RSpec.describe 'Firm factory' do
     specify 'expected status' do
       expect(subject).to be_persisted
       expect(subject).to be_valid
-      expect(subject).not_to be_publishable
+      expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
       expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
       expect(subject.principal).not_to be_present
-      expect(subject).to have(:no).offices
+      expect(subject).to have(1).offices
       expect(subject).to have(3).advisers
       expect(subject).to have(:no).trading_names
     end
@@ -110,14 +110,14 @@ RSpec.describe 'Firm factory' do
     specify 'expected status' do
       expect(subject).to be_persisted
       expect(subject).to be_valid
-      expect(subject).not_to be_publishable
+      expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
       expect(subject.primary_advice_method).to be(:local)
     end
 
     specify 'associations' do
       expect(subject.principal).not_to be_present
-      expect(subject).to have(:no).offices
+      expect(subject).to have(1).offices
       expect(subject).to have(:no).advisers
 
       expect(subject).to have(3).trading_names
@@ -132,7 +132,7 @@ RSpec.describe 'Firm factory' do
     specify 'expected status' do
       expect(subject).to be_persisted
       expect(subject).to be_valid
-      expect(subject).not_to be_publishable
+      expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
       expect(subject.primary_advice_method).to be(:local)
     end
@@ -145,7 +145,7 @@ RSpec.describe 'Firm factory' do
       # so that we can check that nothing gets broken by fixing this
       # expect(subject.principal.firm).to eq(subject)
 
-      expect(subject).to have(:no).offices
+      expect(subject).to have(1).offices
       expect(subject).to have(:no).advisers
       expect(subject).to have(:no).trading_names
     end
@@ -157,14 +157,14 @@ RSpec.describe 'Firm factory' do
     specify 'expected status' do
       expect(subject).to be_persisted
       expect(subject).to be_valid
-      expect(subject).not_to be_publishable
+      expect(subject).to be_publishable
       expect(subject).not_to be_trading_name
       expect(subject.primary_advice_method).to be(:remote)
     end
 
     specify 'associations' do
       expect(subject.principal).not_to be_present
-      expect(subject).to have(:no).offices
+      expect(subject).to have(1).offices
       expect(subject).to have(:no).advisers
       expect(subject).to have(:no).trading_names
     end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Firm do
   end
 
   describe '#offices' do
-    let(:firm) { create(:firm) }
+    let(:firm) { create(:firm, offices_count: 0) }
     let!(:unsorted_offices) do
       [
         FactoryGirl.create(:office, firm: firm, address_line_one: 'fourth', created_at: Time.zone.now),
@@ -100,7 +100,7 @@ RSpec.describe Firm do
   end
 
   describe '#main_office' do
-    let(:firm) { create(:firm) }
+    let(:firm) { create(:firm, offices_count: 0) }
     subject { firm.main_office }
 
     context 'when the firm has no offices' do
@@ -117,14 +117,15 @@ RSpec.describe Firm do
   end
 
   describe '#publishable?' do
-    subject { create(:firm) }
+    subject { create(:firm, offices_count: offices_count) }
 
     context 'when the firm has no main office' do
+      let(:offices_count) { 0 }
       it { expect(subject).not_to be_publishable }
     end
 
     context 'when the firm has a main office' do
-      before { FactoryGirl.create(:office, firm: subject) }
+      let(:offices_count) { 1 }
       it { expect(subject).to be_publishable }
     end
   end


### PR DESCRIPTION
Before we implemented multiple offices creating a Firm using the `:firm` factory meant you could assume it would be indexed into ElasticSearch. That got broken because the default `:firm` factory created no offices and to be 'publishable' Firms need at least one. This broke many tests in rad_consumer where everything needs to be accessed via ElasticSearch.

Therefore we now create at least 1 office by default, but you can trigger creation of more by setting the `offices_count` transient.

Note all tests in current rad master pass running against this branch.