### PR TITLE
[DEV APPROVED] A firm should only be publishable if it is valid, has an office and is not missing advisers

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -199,7 +199,7 @@ class Firm < ActiveRecord::Base
   end
 
   def missing_advisers?
-    primary_advice_method == :local && advisers.empty?
+    (primary_advice_method == :local) && advisers.empty?
   end
 
   private

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -195,7 +195,7 @@ class Firm < ActiveRecord::Base
   end
 
   def publishable?
-    main_office.present?
+    valid? && main_office.present?
   end
 
   private

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -195,7 +195,11 @@ class Firm < ActiveRecord::Base
   end
 
   def publishable?
-    valid? && main_office.present?
+    valid? && main_office.present? && !missing_advisers?
+  end
+
+  def missing_advisers?
+    primary_advice_method == :local && advisers.empty?
   end
 
   private

--- a/spec/factories/adviser.rb
+++ b/spec/factories/adviser.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     travel_distance '650'
     latitude  { Faker::Address.latitude.to_f.round(6) }
     longitude { Faker::Address.longitude.to_f.round(6) }
-    firm
+    firm factory: :firm_without_advisers
 
     after(:build) do |a, evaluator|
       if a.reference_number? && evaluator.create_linked_lookup_advisor

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -34,6 +34,14 @@ FactoryGirl.define do
       firm.reload
     end
 
+    transient do
+      advisers_count 1
+    end
+
+    after(:create) do |firm, evaluator|
+      create_list(:adviser, evaluator.advisers_count, firm: firm)
+    end
+
     factory :onboarded_firm, traits: [:with_advisers] do
       advisers_count 1
     end
@@ -67,13 +75,7 @@ FactoryGirl.define do
     end
 
     trait :with_advisers do
-      transient do
-        advisers_count 3
-      end
-
-      after(:create) do |firm, evaluator|
-        create_list(:adviser, evaluator.advisers_count, firm: firm)
-      end
+      advisers_count 3
     end
 
     trait :with_principal do

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   sequence(:registered_name) { |n| "Financial Advice #{n} Ltd." }
 
-  factory :firm, aliases: [:publishable_firm] do
+  factory :firm, aliases: [:publishable_firm, :onboarded_firm] do
     fca_number
     registered_name
     email_address { Faker::Internet.email }
@@ -42,12 +42,6 @@ FactoryGirl.define do
       create_list(:adviser, evaluator.advisers_count, firm: firm)
     end
 
-    factory :onboarded_firm, traits: [:with_advisers] do
-      advisers_count 1
-    end
-
-    factory :not_onboarded_firm, traits: [:invalid]
-
     factory :trading_name, aliases: [:subsidiary] do
       parent factory: Firm
     end
@@ -60,7 +54,7 @@ FactoryGirl.define do
     factory :firm_with_remote_advice, traits: [:with_remote_advice]
     factory :firm_with_subsidiaries, traits: [:with_trading_names]
     factory :firm_with_trading_names, traits: [:with_trading_names]
-    factory :invalid_firm, traits: [:invalid]
+    factory :invalid_firm, traits: [:invalid], aliases: [:not_onboarded_firm]
 
     trait :invalid do
       email_address nil

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -53,6 +53,7 @@ FactoryGirl.define do
     end
 
     factory :firm_with_advisers, traits: [:with_advisers]
+    factory :firm_without_advisers, traits: [:without_advisers]
     factory :firm_with_offices, traits: [:with_offices]
     factory :firm_with_principal, traits: [:with_principal]
     factory :firm_with_no_business_split, traits: [:with_no_business_split]
@@ -76,6 +77,10 @@ FactoryGirl.define do
 
     trait :with_advisers do
       advisers_count 3
+    end
+
+    trait :without_advisers do
+      advisers_count 0
     end
 
     trait :with_principal do

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -246,10 +246,12 @@ RSpec.describe Adviser do
 
   describe '#on_firms_with_fca_number' do
     it 'returns advisers on firm and its trading names' do
-      firm = FactoryGirl.create(:firm)
-      trading_name = FactoryGirl.create(:trading_name, fca_number: firm.fca_number)
-      advisers = [FactoryGirl.create(:adviser, firm_id: firm.id),
-                  FactoryGirl.create(:adviser, firm_id: trading_name.id)]
+      firm = FactoryGirl.create(:firm_with_advisers, advisers_count: 1)
+      trading_name = FactoryGirl.create(:trading_name,
+                                        :with_advisers,
+                                        advisers_count: 1,
+                                        fca_number: firm.fca_number)
+      advisers = [firm.advisers.first, trading_name.advisers.first]
 
       returned_advisers = Adviser.on_firms_with_fca_number(firm.fca_number)
       expect(returned_advisers.length).to eq(2)

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -85,6 +85,25 @@ RSpec.describe 'Firm factory' do
     end
   end
 
+  describe 'factory :firm_without_advisers' do
+    let(:factory) { :firm_without_advisers }
+
+    specify 'expected status' do
+      expect(subject).to be_persisted
+      expect(subject).to be_valid
+      expect(subject).not_to be_publishable
+      expect(subject).not_to be_trading_name
+      expect(subject.primary_advice_method).to be(:local)
+    end
+
+    specify 'associations' do
+      expect(subject.principal).not_to be_present
+      expect(subject).to have(1).offices
+      expect(subject).to have(0).advisers
+      expect(subject).to have(:no).trading_names
+    end
+  end
+
   describe 'factory :firm_with_offices' do
     let(:factory) { :firm_with_offices }
 

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -28,44 +28,6 @@ RSpec.describe 'Firm factory' do
     end
   end
 
-  describe 'factory :onboarded_firm' do
-    let(:factory) { :onboarded_firm }
-
-    specify 'expected status' do
-      expect(subject).to be_persisted
-      expect(subject).to be_valid
-      expect(subject).to be_publishable
-      expect(subject).not_to be_trading_name
-      expect(subject.primary_advice_method).to be(:local)
-    end
-
-    specify 'associations' do
-      expect(subject.principal).not_to be_present
-      expect(subject).to have(1).offices
-      expect(subject).to have(1).advisers
-      expect(subject).to have(:no).trading_names
-    end
-  end
-
-  describe 'factory :not_onboarded_firm' do
-    let(:factory) { :not_onboarded_firm }
-
-    specify 'expected status' do
-      expect(subject).not_to be_persisted
-      expect(subject).not_to be_valid
-      expect(subject).not_to be_publishable
-      expect(subject).not_to be_trading_name
-      expect(subject.primary_advice_method).to be(:local)
-    end
-
-    specify 'associations' do
-      expect(subject.principal).not_to be_present
-      expect(subject).to have(:no).offices
-      expect(subject).to have(:no).advisers
-      expect(subject).to have(:no).trading_names
-    end
-  end
-
   describe 'factory :firm_with_advisers' do
     let(:factory) { :firm_with_advisers }
 

--- a/spec/models/firm_factory_spec.rb
+++ b/spec/models/firm_factory_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Firm factory' do
     specify 'associations' do
       expect(subject.principal).not_to be_present
       expect(subject).to have(1).offices
-      expect(subject).to have(:no).advisers
+      expect(subject).to have(1).advisers
       expect(subject).to have(:no).trading_names
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe 'Firm factory' do
     specify 'associations' do
       expect(subject.principal).not_to be_present
       expect(subject).to have(3).offices
-      expect(subject).to have(:no).advisers
+      expect(subject).to have(1).advisers
       expect(subject).to have(:no).trading_names
     end
   end
@@ -118,7 +118,7 @@ RSpec.describe 'Firm factory' do
     specify 'associations' do
       expect(subject.principal).not_to be_present
       expect(subject).to have(1).offices
-      expect(subject).to have(:no).advisers
+      expect(subject).to have(1).advisers
 
       expect(subject).to have(3).trading_names
       expect(subject.trading_names).to all(have_attributes(fca_number: subject.fca_number))
@@ -146,7 +146,7 @@ RSpec.describe 'Firm factory' do
       # expect(subject.principal.firm).to eq(subject)
 
       expect(subject).to have(1).offices
-      expect(subject).to have(:no).advisers
+      expect(subject).to have(1).advisers
       expect(subject).to have(:no).trading_names
     end
   end
@@ -165,7 +165,7 @@ RSpec.describe 'Firm factory' do
     specify 'associations' do
       expect(subject.principal).not_to be_present
       expect(subject).to have(1).offices
-      expect(subject).to have(:no).advisers
+      expect(subject).to have(1).advisers
       expect(subject).to have(:no).trading_names
     end
   end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -117,33 +117,34 @@ RSpec.describe Firm do
   end
 
   describe '#publishable?' do
-    subject { FactoryGirl.create(:firm) }
+    let(:firm) { FactoryGirl.create(:firm) }
+    subject { firm.publishable? }
 
     context 'when the firm is valid, has a main office and is not missing advisers' do
-      it { is_expected.to be_publishable }
+      it { is_expected.to be_truthy }
     end
 
     context 'when the firm is not valid' do
-      subject do
+      let(:firm) do
         FactoryGirl.create(:firm).tap do |f|
           f.email_address = nil
           f.save(validate: false)
         end
       end
 
-      it { is_expected.not_to be_publishable }
+      it { is_expected.to be_falsey }
     end
 
     context 'when the firm has no main office' do
-      subject { FactoryGirl.create(:firm, offices_count: 0) }
+      let(:firm) { FactoryGirl.create(:firm, offices_count: 0) }
 
-      it { is_expected.not_to be_publishable }
+      it { is_expected.to be_falsey }
     end
 
     context 'when the firm is missing advisers' do
-      before { allow(subject).to receive(:missing_advisers?).and_return(true) }
+      before { allow(firm).to receive(:missing_advisers?).and_return(true) }
 
-      it { is_expected.not_to be_publishable }
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -117,16 +117,27 @@ RSpec.describe Firm do
   end
 
   describe '#publishable?' do
-    subject { create(:firm, offices_count: offices_count) }
+    context 'when the firm is not valid' do
+      subject do
+        FactoryGirl.create(:firm).tap do |f|
+          f.email_address = nil
+          f.save(validate: false)
+        end
+      end
 
-    context 'when the firm has no main office' do
-      let(:offices_count) { 0 }
-      it { expect(subject).not_to be_publishable }
+      it { is_expected.not_to be_publishable }
     end
 
-    context 'when the firm has a main office' do
-      let(:offices_count) { 1 }
-      it { expect(subject).to be_publishable }
+    context 'when the firm has no main office' do
+      subject { FactoryGirl.create(:firm, offices_count: 0) }
+
+      it { is_expected.not_to be_publishable }
+    end
+
+    context 'when the firm is valid and has a main office' do
+      subject { FactoryGirl.create(:firm) }
+
+      it { is_expected.to be_publishable }
     end
   end
 

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe Firm do
   end
 
   describe '#publishable?' do
+    subject { FactoryGirl.create(:firm) }
+
+    context 'when the firm is valid, has a main office and is not missing advisers' do
+      it { is_expected.to be_publishable }
+    end
+
     context 'when the firm is not valid' do
       subject do
         FactoryGirl.create(:firm).tap do |f|
@@ -134,10 +140,41 @@ RSpec.describe Firm do
       it { is_expected.not_to be_publishable }
     end
 
-    context 'when the firm is valid and has a main office' do
-      subject { FactoryGirl.create(:firm) }
+    context 'when the firm is missing advisers' do
+      before { allow(subject).to receive(:missing_advisers?).and_return(true) }
 
-      it { is_expected.to be_publishable }
+      it { is_expected.not_to be_publishable }
+    end
+  end
+
+  describe '#missing_advisers?' do
+    let(:factory) { :firm }
+    subject { FactoryGirl.create(factory, advisers_count: advisers_count).missing_advisers? }
+
+    context 'when the firm offers face-to-face advice' do
+      context 'when the firm has advisers' do
+        let(:advisers_count) { 1 }
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the firm has no advisers' do
+        let(:advisers_count) { 0 }
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    context 'when the firm offers remote advice' do
+      let(:factory) { :firm_with_remote_advice }
+
+      context 'when the firm has advisers' do
+        let(:advisers_count) { 1 }
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the firm has no advisers' do
+        let(:advisers_count) { 0 }
+        it { is_expected.to be_falsey }
+      end
     end
   end
 

--- a/spec/models/principal_spec.rb
+++ b/spec/models/principal_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe Principal do
 
     context 'when principal has a parent firm and a trading name' do
       let(:parent_firm)   { principal.firm }
-      let!(:trading_name) { create(:firm, registered_name: 'cabbage', parent_id: parent_firm.id, fca_number: principal.fca_number) }
+      let!(:trading_name) { create(:firm_without_advisers, registered_name: 'cabbage', parent_id: parent_firm.id, fca_number: principal.fca_number) }
 
       before :each do
         parent_firm.update_column(:email_address, 'acme@example.com')

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FirmSerializer do
   let(:firm) do
-    create(:firm, principal: create(:principal)) { |f| create(:adviser, firm: f) }
+    FactoryGirl.create(:firm_with_principal)
   end
 
   describe 'the serialized json' do


### PR DESCRIPTION
# Summary

This change tightens up the rules that govern when a firm record is exposed to the consumer directory data store (ElasticSearch).

My rationale is this: it's easier to guard against (and reason about) invalid data being exposed to the directory with simple checks here in the model, than it is to guard against (or even imagine) all combinations of missing data or weakly specified queries in the directory.

# Rules implemented

1) A firm should not be discoverable in the directory if it offers face-to-face advice but does not have any advisers. In this state the firm should not be considered publishable.

2) It is possible to add offices and advisers to a firm before the firm record has been completely filled out. In this state the firm should not be considered publishable until it is also valid.

# Notable changes

After implementing the change:

* `Firm#publishable?` now implements the above logic in addition to the existing check for at least one office.
* There is a new `Firm#missing_advisers?` method that provides a home for the logic to check whether the firm is a face-to-face without any advisers.
* The default `:firm` factory now creates 1 adviser by default so we can rely on fixtures being publishable (unless we explicitly want otherwise)
* The `:onboarded_firm` factory is no longer different to the default `:firm` factory, so it becomes an alias of the latter.
* There is a new `:firm_without_advisers` factory for convenience and clarity for those tests that need it (there turned out to be several).