### PR TITLE
We must use after commit hook for indexing to ElasticSearch

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -64,7 +64,8 @@ class Adviser < ActiveRecord::Base
   private
 
   # All record of what changed is gone by the time we get to the after_commit
-  # hooks, so we need to store any important changes here to be actioned later.
+  # hooks. So we cannot use #firm_id_changed? at that point. To work around
+  # this we flag any important changes here to be actioned later.
   def flag_changes_for_after_commit
     @old_firm_id = firm_id_change.first if firm_id_changed?
   end

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -31,9 +31,9 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
+  after_save :flag_changes_for_after_commit
   after_commit :geocode_and_reindex_firm
-  after_commit :reindex_old_firm, if: :firm_id_changed?
-
+  after_commit :reindex_old_firm
   scope :sorted_by_name, -> { order(:name) }
 
   def self.on_firms_with_fca_number(fca_number)
@@ -63,6 +63,12 @@ class Adviser < ActiveRecord::Base
 
   private
 
+  # All record of what changed is gone by the time we get to the after_commit
+  # hooks, so we need to store any important changes here to be actioned later.
+  def flag_changes_for_after_commit
+    @old_firm_id = firm_id_change.first if firm_id_changed?
+  end
+
   def geocode_and_reindex_firm
     if destroyed?
       firm.geocode_and_reindex
@@ -72,7 +78,8 @@ class Adviser < ActiveRecord::Base
   end
 
   def reindex_old_firm
-    IndexFirmJob.perform_later(Firm.find(attribute_was(:firm_id)))
+    IndexFirmJob.perform_later(Firm.find(@old_firm_id)) if @old_firm_id.present?
+    @old_firm_id = nil
   end
 
   def upcase_postcode

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -109,7 +109,7 @@ class Firm < ActiveRecord::Base
   validates :investment_sizes,
     length: { minimum: 1 }
 
-  after_save :publish_to_elastic_search
+  after_commit :publish_to_elastic_search
   after_commit :delete_elastic_search_entry, if: :destroyed?
 
   def publish_to_elastic_search

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -109,7 +109,7 @@ class Firm < ActiveRecord::Base
   validates :investment_sizes,
     length: { minimum: 1 }
 
-  after_commit :publish_to_elastic_search
+  after_commit :publish_to_elastic_search, unless: :destroyed?
   after_commit :delete_elastic_search_entry, if: :destroyed?
 
   def publish_to_elastic_search

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -395,6 +395,7 @@ RSpec.describe Firm do
       it 'the firm is published' do
         allow(IndexFirmJob).to receive(:perform_later)
         firm = create :firm
+        firm.run_callbacks(:commit)
         expect(IndexFirmJob).to have_received(:perform_later).with(firm)
       end
     end
@@ -404,6 +405,7 @@ RSpec.describe Firm do
         firm = create :firm
         allow(IndexFirmJob).to receive(:perform_later)
         firm.update_attributes(email_address: 'bill@example.com')
+        firm.run_callbacks(:commit)
         expect(IndexFirmJob).to have_received(:perform_later).with(firm)
       end
     end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -478,8 +478,9 @@ RSpec.describe Firm do
           firm.run_callbacks(:commit)
         end
 
-        it 'does not trigger geocoding of the firm' do
+        it 'does not trigger geocoding/reindexing of the firm' do
           expect(GeocodeFirmJob).not_to receive(:perform_later)
+          expect(IndexFirmJob).not_to receive(:perform_later)
           adviser = firm.advisers.first
           office = firm.offices.first
           firm.destroy


### PR DESCRIPTION
# The problem

We cannot use the `after_save` callback for reindexing. From the [Rails docs on after_save](http://apidock.com/rails/ActiveRecord/Callbacks/after_save)

`"Note that this callback is still wrapped in the transaction around save. For example, if you invoke an external indexer at this point it won’t see the changes in the database."`

# What has changed?

1. `Firm#publish_to_elastic_search` is now called on `after_commit` again unless the firm is being destroyed.
2. Once the above was done, reindexing the previous parent firm for an adviser being moved stopped working as the `firm_id_changed?` method will return false after the transaction has been committed. So reverted previous commit to fix this behaviour.