### PR TITLE
Ensure firms are removed from ElasticSearch if they become unpublishable

### DIFF
--- a/app/jobs/index_firm_job.rb
+++ b/app/jobs/index_firm_job.rb
@@ -4,6 +4,10 @@ class IndexFirmJob < ActiveJob::Base
   end
 
   def perform(firm)
-    FirmRepository.new.store(firm) if firm.publishable?
+    if firm.publishable?
+      FirmRepository.new.store(firm)
+    else
+      DeleteFirmJob.perform_later(firm.id)
+    end
   end
 end

--- a/spec/jobs/index_firm_job_spec.rb
+++ b/spec/jobs/index_firm_job_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe IndexFirmJob, '#perform' do
   let(:repository) { instance_double(FirmRepository) }
-  let(:firm) { Firm.new }
+  let(:firm_id) { 3 }
+  let(:firm) { Firm.new(id: firm_id) }
 
   before do
     allow(FirmRepository).to receive(:new).and_return(repository)
@@ -24,6 +25,11 @@ RSpec.describe IndexFirmJob, '#perform' do
 
     it 'does not delegates to the firm repository' do
       expect(repository).not_to receive(:store).with(firm)
+      described_class.new.perform(firm)
+    end
+
+    it 'invokes the DeleteFirmJob to remove the firm from the directory' do
+      expect(DeleteFirmJob).to receive(:perform_later).with(firm_id)
       described_class.new.perform(firm)
     end
   end


### PR DESCRIPTION
Although the exiting code guarded against firms being published before
they are ready, it did not deal with the case where a firm becomes
unpublishable again at some point after being published.

New logic added to delete the entry from ElasticSearch if this happens.