### PR TITLE
Optimise Firm#publishable?

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -195,7 +195,7 @@ class Firm < ActiveRecord::Base
   end
 
   def publishable?
-    valid? && main_office.present? && !missing_advisers?
+    registered? && main_office.present? && !missing_advisers?
   end
 
   def missing_advisers?

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -199,7 +199,7 @@ class Firm < ActiveRecord::Base
   end
 
   def publishable?
-    registered? && main_office.present? && !missing_advisers?
+    registered? && offices.any? && !missing_advisers?
   end
 
   def missing_advisers?

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -126,6 +126,10 @@ class Firm < ActiveRecord::Base
            to: :main_office,
            allow_nil: true
 
+  # A heuristic that allows us to infer validity
+  #
+  # This method is basically a cheap way to answer the question: has this
+  # record ever been saved with validation enabled?
   def registered?
     email_address.present?
   end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -126,10 +126,7 @@ RSpec.describe Firm do
 
     context 'when the firm is not valid' do
       let(:firm) do
-        FactoryGirl.create(:firm).tap do |f|
-          f.email_address = nil
-          f.save(validate: false)
-        end
+        FactoryGirl.build(:invalid_firm).tap { |f| f.save(validate: false) }
       end
 
       it { is_expected.to be_falsey }


### PR DESCRIPTION
When PR https://github.com/moneyadviceservice/mas-rad_core/pull/104 gets merged, `Firm#publishable?` will get called for every firm/trading name associated with a principal, for every page of self-service that should show an onboarding message. Therefore I decided to take this opportunity to optimise it.

The main problem seemed to be calling `#valid?`. By using the `#registered?` method instead, which is basically a heuristic check for validity, `publishable?` now runs in 1/10th of the time.

On benchmarking with a firm that has 100 invalid trading names the total system+user CPU time when calling Principal#onboarded? was about 1.0 second.

After making these changes this went down to 0.1 seconds.