### PR TITLE
Use email and phone fields from main_office and remove from firm

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -10,7 +10,7 @@ class Firm < ActiveRecord::Base
     :wills_and_probate_flag
   ]
 
-  scope :registered, -> { where.not(email_address: nil) }
+  scope :registered, -> { where.not(free_initial_meeting: nil) }
   scope :sorted_by_registered_name, -> { order(:registered_name) }
 
   has_and_belongs_to_many :in_person_advice_methods
@@ -131,7 +131,8 @@ class Firm < ActiveRecord::Base
   # This method is basically a cheap way to answer the question: has this
   # record ever been saved with validation enabled?
   def registered?
-    email_address.present?
+    # free_initial_meeting may be false when set so we cannot use `.present?`
+    !free_initial_meeting.nil?
   end
 
   enum status: { independent: 1, restricted: 2 }

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -39,16 +39,6 @@ class Firm < ActiveRecord::Base
   before_validation :clear_blank_languages
   before_validation :deduplicate_languages
 
-  validates :email_address,
-    presence: true,
-    length: { maximum: 50 },
-    format: { with: /.+@.+\..+/ }
-
-  validates :telephone_number,
-    presence: true,
-    length: { maximum: 30 },
-    format: { with: /\A[0-9 ]+\z/ }
-
   validates :website_address,
     allow_blank: true,
     length: { maximum: 100 },
@@ -137,12 +127,6 @@ class Firm < ActiveRecord::Base
 
   enum status: { independent: 1, restricted: 2 }
 
-  def telephone_number
-    return nil unless self[:telephone_number]
-
-    self[:telephone_number].gsub(' ', '')
-  end
-
   def in_person_advice?
     in_person_advice_methods.present?
   end
@@ -156,8 +140,6 @@ class Firm < ActiveRecord::Base
 
   def field_order
     [
-      :email_address,
-      :telephone_number,
       :website_address,
       :address_line_one,
       :address_line_two,

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -40,6 +40,14 @@ class FirmSerializer < ActiveModel::Serializer
     object.advisers.geocoded
   end
 
+  def telephone_number
+    object.main_office.telephone_number
+  end
+
+  def email_address
+    object.main_office.email_address
+  end
+
   def postcode_searchable
     object.postcode_searchable?
   end

--- a/db/migrate/20150930140851_remove_firm_email_and_phone.rb
+++ b/db/migrate/20150930140851_remove_firm_email_and_phone.rb
@@ -1,0 +1,26 @@
+class RemoveFirmEmailAndPhone < ActiveRecord::Migration
+  class Firm < ActiveRecord::Base; has_many :offices, -> { order created_at: :asc }; end
+  class Office < ActiveRecord::Base; belongs_to :firm; end
+
+  def up
+    remove_column :firms, :email_address
+    remove_column :firms, :telephone_number
+
+    # Data does not need to be migrated as the offices migration will have
+    # already copied these two fields into an office record.
+  end
+
+  def down
+    add_column :firms, :email_address, :string
+    add_column :firms, :telephone_number, :string
+
+    # Use the equivalent main office fields to repopulate
+    Firm.all.select { |f| f.offices.any? }.each do |firm|
+      main_office = firm.offices.first
+      firm.update!(
+        email_address: main_office.email_address,
+        telephone_number: main_office.telephone_number
+      )
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150825090822) do
+ActiveRecord::Schema.define(version: 20150930140851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,8 +80,6 @@ ActiveRecord::Schema.define(version: 20150825090822) do
   create_table "firms", force: :cascade do |t|
     t.integer  "fca_number",                                               null: false
     t.string   "registered_name",                                          null: false
-    t.string   "email_address"
-    t.string   "telephone_number"
     t.datetime "created_at",                                               null: false
     t.datetime "updated_at",                                               null: false
     t.boolean  "free_initial_meeting"
@@ -99,8 +97,8 @@ ActiveRecord::Schema.define(version: 20150825090822) do
     t.string   "website_address"
     t.boolean  "ethical_investing_flag",                   default: false, null: false
     t.boolean  "sharia_investing_flag",                    default: false, null: false
-    t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
+    t.text     "languages",                                default: [],    null: false, array: true
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -4,8 +4,6 @@ FactoryGirl.define do
   factory :firm, aliases: [:publishable_firm, :onboarded_firm] do
     fca_number
     registered_name
-    email_address { Faker::Internet.email }
-    telephone_number { Faker::Base.numerify('##### ### ###') }
     website_address { Faker::Internet.url }
     in_person_advice_methods { create_list(:in_person_advice_method, rand(1..3)) }
     free_initial_meeting { [true, false].sample }

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -57,7 +57,7 @@ FactoryGirl.define do
     factory :invalid_firm, traits: [:invalid], aliases: [:not_onboarded_firm]
 
     trait :invalid do
-      email_address nil
+      free_initial_meeting nil
     end
 
     trait :with_no_business_split do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -18,13 +18,18 @@ RSpec.describe Firm do
   end
 
   describe '#registered?' do
-    it 'is false if the firm has no email address' do
-      firm.email_address = nil
+    it 'is false if the free_initial_meeting field is nil' do
+      firm.free_initial_meeting = nil
       expect(firm).not_to be_registered
     end
 
-    it 'is true if the firm has an email address' do
-      firm.email_address = 'acme@example.com'
+    it 'is true if the free_initial_meeting field is false' do
+      firm.free_initial_meeting = false
+      expect(firm).to be_registered
+    end
+
+    it 'is true if the free_initial_meeting field is true' do
+      firm.free_initial_meeting = true
       expect(firm).to be_registered
     end
   end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -34,22 +34,6 @@ RSpec.describe Firm do
     end
   end
 
-  describe '#telephone_number' do
-    context 'when `nil`' do
-      it 'returns `nil`' do
-        expect(build(:firm, telephone_number: nil).telephone_number).to be_nil
-      end
-    end
-
-    context 'when provided' do
-      let(:firm) { build(:firm, telephone_number: ' 07715 930 457  ') }
-
-      it 'removes whitespace' do
-        expect(firm.telephone_number).to eq('07715930457')
-      end
-    end
-  end
-
   describe '#postcode_searchable?' do
     it 'delegates to #in_person_advice?' do
       expect(firm).to be_postcode_searchable
@@ -188,34 +172,6 @@ RSpec.describe Firm do
 
     it 'orders fields correctly for dough' do
       expect(firm.field_order).not_to be_empty
-    end
-
-    describe 'email address' do
-      context 'when not present' do
-        before { firm.email_address = nil }
-
-        it { is_expected.to_not be_valid }
-      end
-
-      context 'when badly formatted' do
-        before { firm.email_address = 'not-valid' }
-
-        it { is_expected.to_not be_valid }
-      end
-    end
-
-    describe 'telephone number' do
-      context 'when not present' do
-        before { firm.telephone_number = nil }
-
-        it { is_expected.to_not be_valid }
-      end
-
-      context 'when badly formatted' do
-        before { firm.telephone_number = 'not-valid' }
-
-        it { is_expected.to_not be_valid }
-      end
     end
 
     describe 'Website address' do
@@ -455,7 +411,7 @@ RSpec.describe Firm do
       it 'the firm is published' do
         firm = create :firm
         allow(IndexFirmJob).to receive(:perform_later)
-        firm.update_attributes(email_address: 'bill@example.com')
+        firm.update_attributes(registered_name: 'A new name')
         firm.run_callbacks(:commit)
         expect(IndexFirmJob).to have_received(:perform_later).with(firm)
       end

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe FirmSerializer do
     end
 
     it 'exposes `telephone_number`' do
-      expect(subject[:telephone_number]).to eql(firm.telephone_number)
+      expect(subject[:telephone_number]).to eql(firm.main_office.telephone_number)
     end
 
     it 'exposes `website_address`' do
@@ -47,7 +47,7 @@ RSpec.describe FirmSerializer do
     end
 
     it 'exposes `email_address`' do
-      expect(subject[:email_address]).to eql(firm.email_address)
+      expect(subject[:email_address]).to eql(firm.main_office.email_address)
     end
 
     it 'exposes `free_initial_meeting`' do


### PR DESCRIPTION
## Summary

There is no longer a good reason to have email and phone contact details in the firm record.

There are too many of these fields in the system (they exist on Principal, Firm and Office) which feels confusing. So instead we now use the details from the `Firm#main_office` and remove the fields from Firm.

## Oh, look how small that ice berg is ...

Unfortunately the `Firm#email_address` field had taken on special extra magical powers in that it was the field used to detect firms that had been fully filled out and saved with validation on (see `Firm#registered?`).

Turns out there aren't many mandatory but simple/scalar Firm fields left that we can use for this trick. Luckily we can use `free_initial_meeting` instead.

## Next steps

Tests will need to be fixed in rad and rad_consumer.

In rad particularly, knowledge has leaked into the tests about the `Firm#email_address` field's magic powers. So I'm going raise another PR after this which encapsulates the `free_initial_meeting` field's new role so we don't get the same leak again.