### PR TITLE
[DEV APPROVED] Attempt to encapsulate the registered marker field inside of Firm (wdyt?)

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -131,6 +131,15 @@ class Firm < ActiveRecord::Base
     !(send(REGISTERED_MARKER_FIELD).nil?)
   end
 
+  if Rails.env.test?
+    # A helper to shield tests from modifying the marker field directly
+    def __set_registered(state)
+      new_value = (state) ? REGISTERED_MARKER_FIELD_VALID_VALUES.first : nil
+      send("#{REGISTERED_MARKER_FIELD}=", new_value)
+    end
+    alias_method :__registered=, :__set_registered
+  end
+
   enum status: { independent: 1, restricted: 2 }
 
   def in_person_advice?

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -55,7 +55,8 @@ FactoryGirl.define do
     factory :invalid_firm, traits: [:invalid], aliases: [:not_onboarded_firm]
 
     trait :invalid do
-      free_initial_meeting nil
+      # Invalidates the marker field without referencing it directly
+      send(Firm::REGISTERED_MARKER_FIELD, nil)
     end
 
     trait :with_no_business_split do

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -55,8 +55,8 @@ FactoryGirl.define do
     factory :invalid_firm, traits: [:invalid], aliases: [:not_onboarded_firm]
 
     trait :invalid do
-      # Invalidates the marker field without referencing it directly
-      send(Firm::REGISTERED_MARKER_FIELD, nil)
+      # Invalidate the marker field without referencing it directly
+      __registered false
     end
 
     trait :with_no_business_split do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -18,19 +18,20 @@ RSpec.describe Firm do
   end
 
   describe '#registered?' do
-    it 'is false if the free_initial_meeting field is nil' do
-      firm.free_initial_meeting = nil
+    def set_marker_field(firm, value)
+      firm.send("#{Firm::REGISTERED_MARKER_FIELD}=", value)
+    end
+
+    it 'is false if the REGISTERED_MARKER_FIELD field is nil' do
+      set_marker_field(firm, nil)
       expect(firm).not_to be_registered
     end
 
-    it 'is true if the free_initial_meeting field is false' do
-      firm.free_initial_meeting = false
-      expect(firm).to be_registered
-    end
-
-    it 'is true if the free_initial_meeting field is true' do
-      firm.free_initial_meeting = true
-      expect(firm).to be_registered
+    it 'is true if the REGISTERED_MARKER_FIELD field has a valid value' do
+      Firm::REGISTERED_MARKER_FIELD_VALID_VALUES.each do |value|
+        set_marker_field(firm, value)
+        expect(firm).to be_registered
+      end
     end
   end
 


### PR DESCRIPTION
As alluded to in https://github.com/moneyadviceservice/mas-rad_core/pull/106, this PR is an attempt to stop magic knowledge spreading about the code bases.

In this change, there is now one and only one place that knows which field in Firm is being used to guess if a record has been fully filled out and saved/validated; the Firm object itself.

## wdyt?

Really interested in opinions on whether this is easier to understand or whether there is a better way to do this.

The only thing I'd like to retain is something like the `Firm#__set_registered` method as I've already started crafting a branch of test fixes on RAD which use it. It is only defined when in `RAILS_ENV=test` and seems to hide the magic nicely.

Also, does the double underscore in `__set_registered` successfully communicate, `"beware this is not normal production compatible code you are using, understand clearly please"`? Because that's what I'm trying to indicate.
`¯\_(ツ)_/¯`

UPDATE you can look at https://github.com/moneyadviceservice/rad/pull/318 to see how `__set_registered` is being used.