### PR TITLE
[DEV APPROVED] add system_name method similiar to friendly_name

### DIFF
--- a/app/models/other_advice_method.rb
+++ b/app/models/other_advice_method.rb
@@ -1,6 +1,12 @@
 class OtherAdviceMethod < ActiveRecord::Base
   include Translatable
   include FriendlyNamable
+  include SystemNameable
+
+  SYSTEM_NAMES = {
+    1 => :phone,
+    2 => :online
+  }
 
   has_and_belongs_to_many :firms
 

--- a/app/models/system_nameable.rb
+++ b/app/models/system_nameable.rb
@@ -1,0 +1,12 @@
+module SystemNameable
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def system_name(id)
+      order = find(id).order
+      self::SYSTEM_NAMES.fetch(order, :not_found)
+    end
+  end
+end

--- a/spec/models/other_advice_method_spec.rb
+++ b/spec/models/other_advice_method_spec.rb
@@ -2,4 +2,5 @@ RSpec.describe OtherAdviceMethod do
   it_behaves_like 'reference data'
   it_behaves_like 'translatable'
   it_behaves_like 'friendly named'
+  it_behaves_like 'system named'
 end

--- a/spec/support/shared_examples/system_named.rb
+++ b/spec/support/shared_examples/system_named.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples 'system named' do
+  let(:type) { described_class.model_name.i18n_key }
+  let(:method) { create(type, order: 1) }
+
+  before do
+    fail unless described_class::SYSTEM_NAMES
+    stub_const("#{described_class.model_name}::SYSTEM_NAMES", { 1 => :phone })
+  end
+
+  subject { described_class.system_name(method.id) }
+
+  it 'returns the corresponding system name' do
+    expect(subject).to eq(:phone)
+  end
+end


### PR DESCRIPTION
This PR introduces the notion of a 'system' name.

Currently, things like the Advice methods for an adviser ("Phone", "Online") are stored as records in the database (`OtherAdviceMethod` objects). These objects have a defined order value associated with them. The significance of this order value has importance when trying to fetch I18n translations for the associated records.

For example:

In the current implementation of fetching text for one of these records, there is a yaml key like `'en.other_advice_methods.ordinal.1'`, which maps to `'Phone'`. An existing `friendly_name` method makes use of this to allow translations to be rendered. This is ok in isolation, but in scenarios where we need to iterate over a collection of objects, and populate more complex UI design, we're finding we're running up against this implementation.

This change introduces a method `system_name`, which instead of returning a translation, returns a sensibly named symbol that represents this object, that way we have more control over translations and conditional logic within any application which uses rad_core.

This also has an advantage of us having these known order numbers as constants on the associated class, instead of being hidden away in translations file.

## how it's used
In the scenario we have an `OtherAdviceMethod` object with an `id` of `5`, but an `order` value of '1'
```ruby
class OtherAdviceMethod
  include SystemNameable
  SYSTEM_NAMES = { 1 => :phone, 2 => :online }
end
```

`OtherAdviceMethod.system_name(5)`, will return `:phone`.

We can then use this symbol in specific translations, rendering of specific assets, or setting up conditionals where needed.
