### PR TITLE
[DEV APPROVED] Update Qualifications/Accreditation factories to generate orders from 1

### DIFF
--- a/spec/factories/accreditation.rb
+++ b/spec/factories/accreditation.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :accreditation do
     sequence(:name) { |n| "Accreditation #{n}" }
-    sequence(:order) { |n| n - 1 }
+    sequence(:order) { |n| n }
   end
 end

--- a/spec/factories/qualification.rb
+++ b/spec/factories/qualification.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :qualification do
     sequence(:name) { |n| "Qualification #{n}" }
-    sequence(:order) { |n| n - 1 }
+    sequence(:order) { |n| n }
   end
 end


### PR DESCRIPTION
This was the only change needed to implement the Qualification/Accreditation filter in rad_consumer

The seeds file in RAD generates the order using .each.with_index(1) so
the indexes generated start at 1.

https://github.com/moneyadviceservice/rad/blob/master/db/seeds.rb#L7
https://github.com/moneyadviceservice/rad/blob/master/db/seeds.rb#L73

So needed to update the factories to do the same.

Checked the tests in rad against this change and found no issues. 