### PR TITLE
[DEV APPROVED] Firm#status no longer needs to be mandatory

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -100,8 +100,6 @@ class Firm < ActiveRecord::Base
     end
   end
 
-  validates :status, presence: true
-
   validates :investment_sizes,
     length: { minimum: 1 }
 

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -353,8 +353,8 @@ RSpec.describe Firm do
 
     describe 'status' do
       context 'without a status' do
-        it 'is not valid' do
-          expect(build(:firm, status: nil)).to_not be_valid
+        it 'is valid' do
+          expect(build(:firm, status: nil)).to be_valid
         end
       end
 


### PR DESCRIPTION
Plans have changed. This field is no longer going to be displayed to the
public. So leaving it mandatory is preventing the RAD admin team from
saving updates to firm records.

This change removes the presence validation.