### PR TITLE
add a method to allow us to check types of advice

### DIFF
--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -1,6 +1,8 @@
 require 'uk_phone_numbers'
 
 class FirmResult
+  PERCENTAGE_FOR_TRUE = 100
+
   LESS_THAN_FIFTY_K_ID = 1
 
   DIRECTLY_MAPPED_FIELDS = [
@@ -51,6 +53,10 @@ class FirmResult
 
   def advisers
     @advisers.map { |adviser_data| AdviserResult.new(adviser_data) }
+  end
+
+  def includes_advice_type?(advice_type)
+    public_send(advice_type) == PERCENTAGE_FOR_TRUE
   end
 
   def types_of_advice

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -177,5 +177,31 @@ RSpec.describe FirmResult do
         end
       end
     end
+
+    describe 'includes_advice_type?' do
+      let(:data) { { 'sort' => [1], '_source' => { 'advisers' => [], key => value } } }
+
+      FirmResult::TYPES_OF_ADVICE_FIELDS.each do |advice_type|
+        describe "attribute [#{advice_type}]" do
+          let(:key) { advice_type.to_s }
+
+          context 'has a value of 0 (false)' do
+            let(:value) { 0 }
+
+            it 'returns false' do
+              expect(subject.includes_advice_type?(key)).to eq(false)
+            end
+          end
+
+          context 'has a value of 100 (true)' do
+            let(:value) { 100 }
+
+            it 'returns true' do
+              expect(subject.includes_advice_type?(key)).to eq(true)
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Instead of relying on a magic number in rad_consumer like so:

```ruby
@firm_result.retirement_income_products == 100
```
We replace it with a method that allows us to ask any of the advice types if they have been included in the firm's results.

```ruby
@firm_result.includes_advice_type? :retirement_income_products
```
This is in response to a request in a PR for rad consumer so we aren't littering a magic number around the codebases: https://github.com/moneyadviceservice/rad_consumer/pull/225#discussion_r42373929
