### PR TITLE
[DEV APPROVED] Separate the geocoding from the geocoding background jobs + name clarification

### DIFF
--- a/app/jobs/geocode_adviser_job.rb
+++ b/app/jobs/geocode_adviser_job.rb
@@ -1,14 +1,10 @@
 class GeocodeAdviserJob < ActiveJob::Base
   def perform(adviser)
-    Geocoder.coordinates(adviser.full_street_address).tap do |coords|
-      adviser.geocode!(coords)
-
-      if coords
-        IndexFirmJob.perform_later(adviser.firm)
-        stat :success
-      else
-        stat :failed
-      end
+    if ModelGeocoder.geocode!(adviser)
+      IndexFirmJob.perform_later(adviser.firm)
+      stat :success
+    else
+      stat :failed
     end
   end
 

--- a/app/jobs/geocode_firm_job.rb
+++ b/app/jobs/geocode_firm_job.rb
@@ -1,14 +1,10 @@
 class GeocodeFirmJob < ActiveJob::Base
   def perform(firm)
-    Geocoder.coordinates(firm.full_street_address).tap do |coordinates|
-      firm.geocode!(coordinates)
-
-      if coordinates
-        IndexFirmJob.perform_later(firm)
-        stat :success
-      else
-        stat :failed
-      end
+    if ModelGeocoder.geocode!(firm)
+      IndexFirmJob.perform_later(firm)
+      stat :success
+    else
+      stat :failed
     end
   end
 

--- a/app/models/geocodable.rb
+++ b/app/models/geocodable.rb
@@ -21,7 +21,7 @@ module Geocodable
     [latitude, longitude]
   end
 
-  def geocode!(coordinates)
+  def update_coordinates!(coordinates)
     self.latitude, self.longitude = coordinates
     update_columns(latitude: latitude, longitude: longitude)
   end

--- a/lib/mas/model_geocoder.rb
+++ b/lib/mas/model_geocoder.rb
@@ -5,7 +5,7 @@ module ModelGeocoder
 
   def self.geocode!(geocodable)
     coordinates = geocode(geocodable)
-    geocodable.geocode!(coordinates)
+    geocodable.update_coordinates!(coordinates)
     coordinates.present?
   end
 end

--- a/lib/mas/model_geocoder.rb
+++ b/lib/mas/model_geocoder.rb
@@ -1,0 +1,11 @@
+module ModelGeocoder
+  def self.geocode(geocodable)
+    Geocoder.coordinates(geocodable.full_street_address)
+  end
+
+  def self.geocode!(geocodable)
+    coordinates = geocode(geocodable)
+    geocodable.geocode!(coordinates)
+    coordinates.present?
+  end
+end

--- a/spec/lib/mas/model_geocoder_spec.rb
+++ b/spec/lib/mas/model_geocoder_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe ModelGeocoder do
+  let(:model_class) do
+    Class.new do
+      attr_accessor :address_line_one, :address_line_two, :address_postcode, :longitude, :latitude
+
+      def geocode!(*args); end
+
+      def full_street_address
+        [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
+      end
+    end
+  end
+
+  let(:model) do
+    model_class.new.tap do |thing|
+      thing.address_line_one = address_line_one
+      thing.address_line_two = address_line_two
+      thing.address_postcode = address_postcode
+    end
+  end
+
+  let(:address_line_one) { '120 Holborn' }
+  let(:address_line_two) { 'London' }
+  let(:address_postcode) { 'EC1N 2TD' }
+  let(:expected_coordinates) { [51.5180697, -0.1085203] }
+
+  describe '#geocode' do
+    context 'when the model address can be geocoded' do
+      it 'returns the coordinates' do
+        VCR.use_cassette('geocode-one-result') do
+          expect(ModelGeocoder.geocode(model)).to eql(expected_coordinates)
+        end
+      end
+    end
+
+    context 'when model address cannot be geocoded' do
+      let(:address_line_one) { '1000 Fantasy Ave' }
+      let(:address_line_two) { 'Neverland' }
+      let(:address_postcode) { 'ABC 123' }
+
+      it 'returns nil' do
+        VCR.use_cassette('geocode-no-results') do
+          expect(ModelGeocoder.geocode(model)).to be(nil)
+        end
+      end
+    end
+  end
+
+  describe '#geocode!' do
+    context 'when the model address can be geocoded' do
+      before do
+        allow(ModelGeocoder).to receive(:geocode).and_return(expected_coordinates)
+      end
+
+      it 'calls model.geocode! with the coordinates' do
+        expect(model).to receive(:geocode!).with(expected_coordinates)
+        ModelGeocoder.geocode!(model)
+      end
+
+      it 'returns the true' do
+        expect(ModelGeocoder.geocode!(model)).to be(true)
+      end
+    end
+
+    context 'when model address cannot be geocoded' do
+      before do
+        allow(ModelGeocoder).to receive(:geocode).and_return(nil)
+      end
+
+      # This side effect is required while the geocoding is done on a background job
+      it 'calls model.geocode! with nil' do
+        expect(model).to receive(:geocode!).with(nil)
+        ModelGeocoder.geocode!(model)
+      end
+
+      it 'returns false' do
+        expect(ModelGeocoder.geocode!(model)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/lib/mas/model_geocoder_spec.rb
+++ b/spec/lib/mas/model_geocoder_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ModelGeocoder do
     Class.new do
       attr_accessor :address_line_one, :address_line_two, :address_postcode, :longitude, :latitude
 
-      def geocode!(*args); end
+      def update_coordinates!(*args); end
 
       def full_street_address
         [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
@@ -52,8 +52,8 @@ RSpec.describe ModelGeocoder do
         allow(ModelGeocoder).to receive(:geocode).and_return(expected_coordinates)
       end
 
-      it 'calls model.geocode! with the coordinates' do
-        expect(model).to receive(:geocode!).with(expected_coordinates)
+      it 'calls model.update_coordinates! with the coordinates' do
+        expect(model).to receive(:update_coordinates!).with(expected_coordinates)
         ModelGeocoder.geocode!(model)
       end
 
@@ -68,8 +68,8 @@ RSpec.describe ModelGeocoder do
       end
 
       # This side effect is required while the geocoding is done on a background job
-      it 'calls model.geocode! with nil' do
-        expect(model).to receive(:geocode!).with(nil)
+      it 'calls model.update_coordinates! with nil' do
+        expect(model).to receive(:update_coordinates!).with(nil)
         ModelGeocoder.geocode!(model)
       end
 

--- a/spec/support/shared_examples/geocodable_examples.rb
+++ b/spec/support/shared_examples/geocodable_examples.rb
@@ -35,12 +35,12 @@ RSpec.shared_examples 'geocodable' do
     end
   end
 
-  describe '#geocode!' do
+  describe '#update_coordinates!' do
     let(:coordinates) { [Faker::Address.latitude, Faker::Address.longitude] }
 
     before do
       expect(job_class).not_to receive(:perform_later)
-      subject.geocode!(coordinates)
+      subject.update_coordinates!(coordinates)
       subject.reload
     end
 


### PR DESCRIPTION
## Motivation

This is the first in a series of PRs intended to make the Office models geocodable. The first few will be refactoring to make that goal easier.

1. Geocoding is relatively inexpensive despite requiring a 3rd party webservice. Why? Because every postcode based search on the consumer frontend makes an inline/blocking request to geocode the postcode given. If there was a problem with that we would soonest see it there.
2. Geocoding models on a background job means geocoding failures don't get reported anywhere, so the user has no idea there's a problem.

This PR separates out the act of geocoding from the GeocodeXJob classes so we have the opportunity to geocode in-request. But also retains the existing background jobs (for now).

## Second issue

`Geocodable#geocode!` feels more like it should be called `update_coordinates!`. So I renamed it as such. Totally open to suggestion for a better name.