### PR TITLE
[DEV APPROVED] Clarify the rules to interpret the advice type numbers

### DIFF
--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -1,7 +1,7 @@
 require 'uk_phone_numbers'
 
 class FirmResult
-  PERCENTAGE_FOR_TRUE = 100
+  ADVICE_TYPE_NOT_SELECTED_VALUE = 0
 
   LESS_THAN_FIFTY_K_ID = 1
 
@@ -57,7 +57,7 @@ class FirmResult
   end
 
   def includes_advice_type?(advice_type)
-    public_send(advice_type) == PERCENTAGE_FOR_TRUE
+    public_send(advice_type) > ADVICE_TYPE_NOT_SELECTED_VALUE
   end
 
   def types_of_advice

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -178,8 +178,8 @@ RSpec.describe FirmResult do
             end
           end
 
-          context 'has a value of 100 (true)' do
-            let(:value) { 100 }
+          context 'has a value > 0 (true)' do
+            let(:value) { 1 }
 
             it 'returns true' do
               expect(subject.includes_advice_type?(key)).to eq(true)


### PR DESCRIPTION
These numbers used to be percentage values but they were converted to booleans. However, a wide range of number values still exist in the production index, so strictly we need to interpret 0 as not selected and > 0 as selected. This intention can be confirmed by looking at the migration when the work was originally done:

https://github.com/moneyadviceservice/mas-rad_core/blob/master/db/migrate/20150630143001_change_percentage_fields_to_boolean_fields_on_firm.rb#L16