### PR TITLE
We shouldn't be calling translations across code bases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.85)
+    mas-rad_core (0.0.86)
       active_model_serializers
       geocoder
       httpclient

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -34,6 +34,7 @@ class FirmResult
   attr_reader :id,
     :name,
     :total_advisers,
+    :closest_adviser,
     *DIRECTLY_MAPPED_FIELDS,
     *TYPES_OF_ADVICE_FIELDS
 
@@ -73,14 +74,6 @@ class FirmResult
 
   def minimum_pot_size?
     minimum_pot_size_id > LESS_THAN_FIFTY_K_ID
-  end
-
-  def closest_adviser
-    if @closest_adviser < 1
-      I18n.t('search.result.miles_away_alt')
-    else
-      "#{format('%.1f', @closest_adviser)} #{I18n.t('search.result.miles_away')}"
-    end
   end
 
   def telephone_number

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.85'
+    VERSION = '0.0.86'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -97,8 +97,8 @@ ActiveRecord::Schema.define(version: 20150930140851) do
     t.string   "website_address"
     t.boolean  "ethical_investing_flag",                   default: false, null: false
     t.boolean  "sharia_investing_flag",                    default: false, null: false
-    t.integer  "status"
     t.text     "languages",                                default: [],    null: false, array: true
+    t.integer  "status"
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -156,25 +156,10 @@ RSpec.describe FirmResult do
     end
 
     describe '#closest_adviser' do
-      let(:text) { 'less than a mile away' }
+      before { data['sort'] = [1.23456789, 2.34567890] }
 
-      before do
-        I18n.backend.store_translations :en,
-          search: { result: { miles_away_alt: text, miles_away: 'miles away' } }
-      end
-
-      context 'when it is less than 1 mile away' do
-        it 'returns `less than a mile away` localised text' do
-          expect(subject.closest_adviser).to eq(text)
-        end
-      end
-
-      context 'when it is a mile away or more' do
-        before { data['sort'] = [1.23456789] }
-
-        it 'returns the formatted distance' do
-          expect(subject.closest_adviser).to eq('1.2 miles away')
-        end
+      it 'returns the first distance' do
+        expect(subject.closest_adviser).to eq(1.23456789)
       end
     end
 


### PR DESCRIPTION
We needed to change the translation for the new design but then realised that it was actually being called from within the gem. The data should not be using the translations (or formatting for that matter) here and so we've moved it back to rad_consumer. The raw value is still passed through from here though.