### PR TITLE
Update firm minimum fixed fee defaults to zero

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.87)
+    mas-rad_core (0.0.88)
       active_model_serializers
       geocoder
       httpclient
@@ -84,7 +84,7 @@ GEM
     minitest (5.6.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    pg (0.18.2)
+    pg (0.18.3)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -67,7 +67,7 @@ class Firm < ActiveRecord::Base
     length: { minimum: 1 }
 
   validates :minimum_fixed_fee,
-    allow_blank: true,
+    allow_blank: false,
     numericality: {
       only_integer: true,
       greater_than_or_equal_to: 0,

--- a/db/migrate/20151102113518_add_default_value_to_minimum_fixed_fee.rb
+++ b/db/migrate/20151102113518_add_default_value_to_minimum_fixed_fee.rb
@@ -1,0 +1,15 @@
+class AddDefaultValueToMinimumFixedFee < ActiveRecord::Migration
+  class Firm < ActiveRecord::Base
+  end
+
+  def up
+    firms = Firm.where(minimum_fixed_fee: nil)
+    firms.each { |f| f.update_attribute('minimum_fixed_fee', 0) }
+
+    change_column_default :firms, :minimum_fixed_fee, 0
+  end
+
+  def down
+    change_column_default :firms, :minimum_fixed_fee, nil
+  end
+end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.87'
+    VERSION = '0.0.88'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150930140851) do
+ActiveRecord::Schema.define(version: 20151102113518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20150930140851) do
     t.datetime "updated_at",                                               null: false
     t.boolean  "free_initial_meeting"
     t.integer  "initial_meeting_duration_id"
-    t.integer  "minimum_fixed_fee"
+    t.integer  "minimum_fixed_fee",                        default: 0
     t.integer  "parent_id"
     t.float    "latitude"
     t.float    "longitude"

--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -8,7 +8,6 @@ FactoryGirl.define do
     in_person_advice_methods { create_list(:in_person_advice_method, rand(1..3)) }
     free_initial_meeting { [true, false].sample }
     initial_meeting_duration { create(:initial_meeting_duration) }
-    minimum_fixed_fee { Faker::Number.number(4) }
     initial_advice_fee_structures { create_list(:initial_advice_fee_structure, rand(1..3)) }
     ongoing_advice_fee_structures { create_list(:ongoing_advice_fee_structure, rand(1..3)) }
     allowed_payment_methods { create_list(:allowed_payment_method, rand(1..3)) }

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -324,10 +324,38 @@ RSpec.describe Firm do
     end
 
     describe 'minimum fixed fee' do
+      context 'default value' do
+        it { expect(Firm.new.minimum_fixed_fee).to eq(0) }
+      end
+
       context 'when not numeric' do
         before { firm.minimum_fixed_fee = 'not-numeric' }
 
         it { is_expected.not_to be_valid }
+      end
+
+      context 'when blank' do
+        before { firm.minimum_fixed_fee = nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when less than zero' do
+        before { firm.minimum_fixed_fee = -1 }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context 'when zero' do
+        before { firm.minimum_fixed_fee = 0 }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when more than zero' do
+        before { firm.minimum_fixed_fee = 1 }
+
+        it { is_expected.to be_valid }
       end
     end
 


### PR DESCRIPTION
Where no minimum fee has been explicitly set by the firms the field remains unset and the directory does not show any information on fees. So for a long time the RAD admin team have been manually updating records to put in £0 whenever they have the opportunity.

Rather than them having to do drive-by updates forever, this change solves this in one shot by setting a default value.