### PR TITLE
[DEV APPROVED] Geocoding offices

### DIFF
--- a/app/models/geocodable.rb
+++ b/app/models/geocodable.rb
@@ -21,8 +21,12 @@ module Geocodable
     [latitude, longitude]
   end
 
-  def update_coordinates!(coordinates)
+  def coordinates=(coordinates)
     self.latitude, self.longitude = coordinates
+  end
+
+  def update_coordinates!(coordinates)
+    self.coordinates = coordinates
     update_columns(latitude: latitude, longitude: longitude)
   end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -95,7 +95,7 @@ class Office < ActiveRecord::Base
   private
 
   def add_geocoding_failed_error
-    errors.add(:address, 'could not be geocoded')
+    errors.add(:address, I18n.t("#{model_name.i18n_key}.geocoding.failure_message"))
   end
 
   def upcase_postcode

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -70,6 +70,7 @@ class Office < ActiveRecord::Base
     return true unless needs_to_be_geocoded?
 
     self.coordinates = ModelGeocoder.geocode(self)
+    add_geocoding_failed_error unless geocoded?
 
     geocoded?
   end
@@ -92,6 +93,10 @@ class Office < ActiveRecord::Base
   end
 
   private
+
+  def add_geocoding_failed_error
+    errors.add(:address, 'could not be geocoded')
+  end
 
   def upcase_postcode
     address_postcode.upcase! if address_postcode.present?

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -82,6 +82,15 @@ class Office < ActiveRecord::Base
     ADDRESS_FIELDS.any? { |field| changed_attributes.include? field }
   end
 
+  def save_with_geocoding
+    geocode && save
+  end
+
+  def update_with_geocoding(office_params)
+    self.attributes = office_params
+    save_with_geocoding
+  end
+
   private
 
   def upcase_postcode

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,4 +1,6 @@
 class Office < ActiveRecord::Base
+  include Geocodable
+
   belongs_to :firm
 
   before_validation :upcase_postcode

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -34,8 +34,6 @@ class Office < ActiveRecord::Base
 
   validates :disabled_access, inclusion: { in: [true, false] }
 
-  after_commit :geocode_and_reindex_firm
-
   def field_order
     [
       :address_line_one,
@@ -61,17 +59,6 @@ class Office < ActiveRecord::Base
 
   def upcase_postcode
     address_postcode.upcase! if address_postcode.present?
-  end
-
-  def geocode_and_reindex_firm
-    return if destroyed?
-    if valid? and main_office?
-      firm.geocode_and_reindex # until we move the geocoding to offices, geocode the firm if this is the main office
-    end
-  end
-
-  def main_office?
-    firm.try(:main_office) == self
   end
 end
 

--- a/db/migrate/20151103161642_add_latitude_and_longitude_to_office.rb
+++ b/db/migrate/20151103161642_add_latitude_and_longitude_to_office.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToOffice < ActiveRecord::Migration
+  def change
+    add_column :offices, :latitude, :float
+    add_column :offices, :longitude, :float
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151102113518) do
+ActiveRecord::Schema.define(version: 20151103161642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,8 @@ ActiveRecord::Schema.define(version: 20151102113518) do
     t.integer  "firm_id",                          null: false
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   create_table "ongoing_advice_fee_structures", force: :cascade do |t|

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Office do
   let(:firm) { FactoryGirl.create(:firm_with_offices, id: 123) }
   subject(:office) { firm.offices.first }
 
+  it_should_behave_like 'geocodable' do
+    let(:job_class) { double }
+  end
+
   describe '#telephone_number' do
     context 'when `nil`' do
       before { office.telephone_number = nil }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -8,6 +8,131 @@ RSpec.describe Office do
     let(:job_class) { double }
   end
 
+  describe '#geocode' do
+    context 'when the subject is not valid' do
+      subject { Office.new }
+
+      it 'does not call the geocoder' do
+        expect(ModelGeocoder).not_to receive(:geocode)
+        subject.geocode
+      end
+
+      it 'returns false' do
+        expect(subject.geocode).to be(false)
+      end
+    end
+
+    context 'when the subject is valid' do
+      subject { FactoryGirl.build(:office, firm: firm) }
+
+      context 'when the subject does not need to be geocoded' do
+        before do
+          allow(subject).to receive(:needs_to_be_geocoded?).and_return(false)
+        end
+
+        it 'does not call the geocoder' do
+          expect(ModelGeocoder).not_to receive(:geocode)
+          subject.geocode
+        end
+
+        it 'returns true' do
+          expect(subject.geocode).to be(true)
+        end
+      end
+
+      context 'when the subject needs to be geocoded' do
+        before do
+          allow(subject).to receive(:needs_to_be_geocoded?).and_return(true)
+        end
+
+        it 'calls the geocoder passing itself' do
+          expect(ModelGeocoder).to receive(:geocode).with(subject)
+          subject.geocode
+        end
+
+        context 'when geocoding succeeds' do
+          before do
+            allow(ModelGeocoder).to receive(:geocode).and_return([1.0, 1.0])
+          end
+
+          it 'returns true' do
+            expect(subject.geocode).to be(true)
+          end
+        end
+
+        context 'when geocoding fails' do
+          before do
+            allow(ModelGeocoder).to receive(:geocode).and_return(nil)
+          end
+
+          it 'returns false' do
+            expect(subject.geocode).to be(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#needs_to_be_geocoded?' do
+    context 'when the model has not been geocoded' do
+      before do
+        expect(subject).not_to be_geocoded
+      end
+
+      it 'returns true' do
+        expect(subject.needs_to_be_geocoded?).to be(true)
+      end
+    end
+
+    context 'when the model has been geocoded' do
+      before do
+        subject.update_coordinates!([1.0, 1.0])
+        expect(subject).to be_geocoded
+      end
+
+      context 'when the model address fields have not changed' do
+        before do
+          expect(subject).not_to have_address_changes
+        end
+
+        it 'returns false' do
+          expect(subject.needs_to_be_geocoded?).to be(false)
+        end
+      end
+
+      context 'when the model address fields have changed' do
+        before do
+          subject.address_postcode = 'SO31 2AY'
+          expect(subject).to have_address_changes
+        end
+
+        it 'returns true' do
+          expect(subject.needs_to_be_geocoded?).to be(true)
+        end
+      end
+    end
+  end
+
+  describe '#has_address_changes?' do
+    context 'when none of the address fields have changed' do
+      it 'returns false' do
+        expect(subject.has_address_changes?).to be(false)
+      end
+    end
+
+    described_class::ADDRESS_FIELDS.each do |field|
+      context "when the model #{field} field has changed" do
+        before do
+          subject.send("#{field}=", 'changed')
+        end
+
+        it 'returns true' do
+          expect(subject.has_address_changes?).to be(true)
+        end
+      end
+    end
+  end
+
   describe '#telephone_number' do
     context 'when `nil`' do
       before { office.telephone_number = nil }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -58,11 +58,21 @@ RSpec.describe Office do
           it 'returns true' do
             expect(subject.geocode).to be(true)
           end
+
+          specify 'subject.errors.count is 0' do
+            subject.geocode
+            expect(subject.errors.count).to be(0)
+          end
         end
 
         context 'when geocoding fails' do
           before do
             allow(ModelGeocoder).to receive(:geocode).and_return(nil)
+          end
+
+          it 'adds an error to subject.errors' do
+            subject.geocode
+            expect(subject.errors).to have_key(:address)
           end
 
           it 'returns false' do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -133,6 +133,62 @@ RSpec.describe Office do
     end
   end
 
+  describe '#save_with_geocoding' do
+    before { allow(office).to receive(:geocode).and_return(result_of_geocoding) }
+    subject { office.save_with_geocoding }
+
+    context 'when geocoding fails' do
+      let(:result_of_geocoding) { false }
+
+      it { is_expected.to be(false) }
+
+      it 'does not call save' do
+        expect(office).not_to receive(:save)
+        subject
+      end
+    end
+
+    context 'when geocoding succeeds' do
+      let(:result_of_geocoding) { true }
+      let(:result_of_saving) { true }
+      before { allow(office).to receive(:save).and_return(result_of_saving) }
+
+      it 'calls save' do
+        expect(office).to receive(:save)
+        subject
+      end
+
+      context 'when saving fails' do
+        let(:result_of_saving) { false }
+        it { is_expected.to be(false) }
+      end
+
+      context 'when saving succeeds' do
+        it { is_expected.to be(true) }
+      end
+    end
+  end
+
+  describe '#update_with_geocoding' do
+    subject { office.update_with_geocoding(address_line_one: '123 xyz street') }
+
+    it 'updates the office with new attributes' do
+      allow(office).to receive(:save_with_geocoding)
+      subject
+      expect(office.changed_attributes).to include(:address_line_one)
+    end
+
+    it 'calls #save_with_geocoding' do
+      expect(office).to receive(:save_with_geocoding)
+      subject
+    end
+
+    it 'returns the return value of #save_with_geocoding' do
+      allow(office).to receive(:save_with_geocoding).and_return(:return_marker)
+      expect(subject).to eq(:return_marker)
+    end
+  end
+
   describe '#telephone_number' do
     context 'when `nil`' do
       before { office.telephone_number = nil }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -1,13 +1,10 @@
 RSpec.describe Office do
   include FieldLengthValidationHelpers
 
-  let(:firm) { nil }
-
-  subject(:office) { FactoryGirl.build(:office, firm: firm) }
+  let(:firm) { FactoryGirl.create(:firm_with_offices, id: 123) }
+  subject(:office) { firm.offices.first }
 
   describe 'after_commit :geocode_and_reindex_firm' do
-    let(:firm) { FactoryGirl.build(:firm, id: 123) }
-
     before do
       ActiveJob::Base.queue_adapter.enqueued_jobs.clear
     end
@@ -193,8 +190,6 @@ RSpec.describe Office do
   end
 
   describe '#full_street_address' do
-    let(:office) { FactoryGirl.build(:office) }
-
     subject { office.full_street_address }
 
     it { is_expected.to eql "#{office.address_line_one}, #{office.address_line_two}, #{office.address_postcode}, United Kingdom"}

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -4,43 +4,6 @@ RSpec.describe Office do
   let(:firm) { FactoryGirl.create(:firm_with_offices, id: 123) }
   subject(:office) { firm.offices.first }
 
-  describe 'after_commit :geocode_and_reindex_firm' do
-    before do
-      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
-    end
-
-    context 'when the address_postcode is not valid' do
-      before { office.address_postcode = nil }
-
-      it 'does not schedule the firm for geocoding' do
-        expect { office.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
-      end
-    end
-
-    context 'when the address_postcode is valid' do
-      context 'but the office is not the main office for the firm' do
-        it 'does not schedule the firm for geocoding' do
-          expect { office.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
-        end
-      end
-
-      context 'and the office is the main office for the firm' do
-        before { allow(firm).to receive(:main_office).and_return(office) }
-
-        it 'schedules the firm for geocoding' do
-          expect { office.run_callbacks(:commit) }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
-        end
-
-        context 'when the office has been destroyed' do
-          it 'does not schedule the firm for geocoding' do
-            office.destroy
-            expect { office.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
-          end
-        end
-      end
-    end
-  end
-
   describe '#telephone_number' do
     context 'when `nil`' do
       before { office.telephone_number = nil }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe Office do
             subject.geocode
             expect(subject.errors.count).to be(0)
           end
+
+          context 'no persistence' do
+            before do
+              subject.save!
+              expect(subject).not_to be_changed
+              expect(subject.coordinates).to eq([nil, nil])
+              subject.geocode
+            end
+
+            it 'sets the new coordinates on the in-memory instance' do
+              expect(subject.coordinates).to eq([1.0, 1.0])
+            end
+
+            it 'does not persist the changed fields' do
+              expect(subject).to be_changed
+              expect(subject.reload.coordinates).to eq([nil, nil])
+            end
+          end
         end
 
         context 'when geocoding fails' do
@@ -73,6 +91,24 @@ RSpec.describe Office do
 
           it 'returns false' do
             expect(subject.geocode).to be(false)
+          end
+
+          context 'no persistence' do
+            before do
+              subject.coordinates = [1.0, 1.0]
+              subject.save!
+              subject.address_postcode = 'SO31 1PY'
+              subject.geocode
+            end
+
+            it 'blanks out the in-memory instance coordinates' do
+              expect(subject.coordinates).to eq([nil, nil])
+            end
+
+            it 'does not persist the changed fields' do
+              expect(subject).to be_changed
+              expect(subject.reload.coordinates).to eq([1.0, 1.0])
+            end
           end
         end
       end

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Office do
 
       context 'when the subject does not need to be geocoded' do
         before do
-          allow(subject).to receive(:needs_to_be_geocoded?).and_return(false)
+          subject.coordinates = [1.0, 1.0]
+          subject.save!
         end
 
         it 'does not call the geocoder' do
@@ -42,12 +43,7 @@ RSpec.describe Office do
 
       context 'when the subject needs to be geocoded' do
         before do
-          allow(subject).to receive(:needs_to_be_geocoded?).and_return(true)
-        end
-
-        it 'calls the geocoder passing itself' do
-          expect(ModelGeocoder).to receive(:geocode).with(subject)
-          subject.geocode
+          subject.coordinates = nil
         end
 
         context 'when geocoding succeeds' do


### PR DESCRIPTION
## Summary

The PR introduces changes to the office model to make it geocodable.

As previously mentioned in #113, geocoding is quick enough that it can be done within the request lifecycle rather than a background job. This has the added benefit that geocoding failures can be reported to the user (which for advisers they currently aren't as they are done on a background job).

So the design here provides a way to geocode synchronously.

## API Examples

Geocoding an in-memory office instance is done by calling:

```ruby
office.geocode
office.changed? # => true, record is dirty because lat/long are set but the record is not saved at this point
``` 

Geocoding and saving can be done by:

```ruby
office = firm.offices.build(office_params)
office.save_with_geocoding # => true if geocoded and saved successfully
```

Or updating as:

```ruby
office.update_with_geocoding(office_params) # => true if geocoded and saved successfully
```

Failure to geocode invalidates the record just like normal validations would so we can report in the UI using existing validations infrastructure:

```ruby
office.update_with_geocoding({ address_postcode: 'XX1 1XX' }) # => false, geocoding fails
office.errors.include?(:address) # => true
```

## Rationale

One thing I wrestled with was whether to try to peg geocoding onto one of ActiveRecord's standard callbacks. But I couldn't settle on a callback to use that didn't have some kind of draw back.

One big issue I had with this was the amount of "surprise" using callbacks causes. E.g. a maintainer might be surprised to find that `office.save` would have the side-effect of issuing an HTTP request to a remote service, while calling `office.save(validate: false)` wouldn't.

Therefore I chose to go with an explicit interface. If you want to geocode then you call `save_with_geocoding` or `update_with_geocoding` which both do what they claim. Both require validation to happen and don't provide a way to let calling code opt-out like `save` does.

## Outstanding Issues

* At this point I've disabled the code which triggers reindexing when changes to an office occur. This PR would be a lot bigger and harder to understand with that included. I plan to get this work approved but not merge it until I have a PR for indexing too.
* I have approval from the product team to retrofit this geocoding strategy to the `Adviser` records so a lot of this new code will be refactored out of `Office` so it can be shared (probably into `Geocodable`).