### PR TITLE
[DEV APPROVED] Firm indexer

### DIFF
--- a/app/jobs/index_firm_job.rb
+++ b/app/jobs/index_firm_job.rb
@@ -4,10 +4,6 @@ class IndexFirmJob < ActiveJob::Base
   end
 
   def perform(firm)
-    if firm.publishable?
-      FirmRepository.new.store(firm)
-    else
-      DeleteFirmJob.perform_later(firm.id)
-    end
+    FirmIndexer.index_firm(firm)
   end
 end

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -72,7 +72,8 @@ class Adviser < ActiveRecord::Base
 
   def geocode_and_reindex_firm
     if destroyed?
-      firm.geocode_and_reindex
+      # TODO Temporary patch up code to make the tests pass
+      FirmIndexer.handle_aggregate_changed(self)
     elsif valid?
       GeocodeAdviserJob.perform_later(self)
     end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -45,6 +45,12 @@ class Office < ActiveRecord::Base
 
   validates :disabled_access, inclusion: { in: [true, false] }
 
+  after_commit :notify_indexer
+
+  def notify_indexer
+    FirmIndexer.handle_aggregate_changed(self)
+  end
+
   def field_order
     [
       :address_line_one,

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -16,17 +16,19 @@ module FirmIndexer
       index_firm(aggregate.firm) if firm_exists?(aggregate.firm)
     end
 
+    def firm_exists?(firm)
+      return false if (firm.nil? || firm.destroyed?)
+      Firm.exists?(firm.id)
+    end
+
+    private
+
     def store_firm(firm)
       FirmRepository.new.store(firm)
     end
 
     def delete_firm(firm)
       FirmRepository.new.delete(firm.id)
-    end
-
-    def firm_exists?(firm)
-      return false if (firm.nil? || firm.destroyed?)
-      Firm.exists?(firm.id)
     end
   end
 end

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -1,14 +1,22 @@
 module FirmIndexer
   def self.index_firm(firm)
-    repo = FirmRepository.new
-
     if firm.publishable?
-      repo.store(firm)
+      store_firm(firm)
     else
-      repo.delete(firm.id)
+      delete_firm(firm)
     end
   end
 
   def self.handle_firm_changed(firm)
+    return delete_firm(firm) if firm.destroyed?
+    index_firm(firm)
+  end
+
+  def self.store_firm(firm)
+    FirmRepository.new.store(firm)
+  end
+
+  def self.delete_firm(firm)
+    FirmRepository.new.delete(firm.id)
   end
 end

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -11,12 +11,17 @@ module FirmIndexer
     alias_method :handle_firm_changed, :index_firm
 
     def handle_aggregate_changed(aggregate)
-      index_firm(aggregate.firm) if firm_exists?(aggregate.firm)
+      # This method may be invoked as part of a cascade delete, in which case
+      # we should do nothing here. The firm change notification will handle
+      # the change.
+      return if associated_firm_destroyed?(aggregate)
+      index_firm(aggregate.firm)
     end
 
-    def firm_exists?(firm)
-      return false if (firm.nil? || firm.destroyed?)
-      Firm.exists?(firm.id)
+    def associated_firm_destroyed?(aggregate)
+      firm = aggregate.firm
+      return true if (firm.nil? || firm.destroyed?)
+      !Firm.exists?(firm.id)
     end
 
     private

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -1,0 +1,11 @@
+module FirmIndexer
+  def self.index_firm(firm)
+    repo = FirmRepository.new
+
+    if firm.publishable?
+      repo.store(firm)
+    else
+      repo.delete(firm.id)
+    end
+  end
+end

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -1,6 +1,6 @@
 module FirmIndexer
   def self.index_firm(firm)
-    if firm.publishable?
+    if !firm.destroyed? && firm.publishable?
       store_firm(firm)
     else
       delete_firm(firm)
@@ -8,7 +8,6 @@ module FirmIndexer
   end
 
   def self.handle_firm_changed(firm)
-    return delete_firm(firm) if firm.destroyed?
     index_firm(firm)
   end
 

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -12,6 +12,7 @@ module FirmIndexer
   end
 
   def self.handle_aggregate_changed(aggregate)
+    index_firm(aggregate.firm) if firm_exists?(aggregate.firm)
   end
 
   def self.store_firm(firm)
@@ -20,5 +21,10 @@ module FirmIndexer
 
   def self.delete_firm(firm)
     FirmRepository.new.delete(firm.id)
+  end
+
+  def self.firm_exists?(firm)
+    return false if (firm.nil? || firm.destroyed?)
+    Firm.exists?(firm.id)
   end
 end

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -11,6 +11,9 @@ module FirmIndexer
     index_firm(firm)
   end
 
+  def self.handle_aggregate_changed(aggregate)
+  end
+
   def self.store_firm(firm)
     FirmRepository.new.store(firm)
   end

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -8,9 +8,7 @@ module FirmIndexer
       end
     end
 
-    def handle_firm_changed(firm)
-      index_firm(firm)
-    end
+    alias_method :handle_firm_changed, :index_firm
 
     def handle_aggregate_changed(aggregate)
       index_firm(aggregate.firm) if firm_exists?(aggregate.firm)

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -8,4 +8,7 @@ module FirmIndexer
       repo.delete(firm.id)
     end
   end
+
+  def self.handle_firm_changed(firm)
+  end
 end

--- a/lib/mas/firm_indexer.rb
+++ b/lib/mas/firm_indexer.rb
@@ -1,30 +1,32 @@
 module FirmIndexer
-  def self.index_firm(firm)
-    if !firm.destroyed? && firm.publishable?
-      store_firm(firm)
-    else
-      delete_firm(firm)
+  class << self
+    def index_firm(firm)
+      if !firm.destroyed? && firm.publishable?
+        store_firm(firm)
+      else
+        delete_firm(firm)
+      end
     end
-  end
 
-  def self.handle_firm_changed(firm)
-    index_firm(firm)
-  end
+    def handle_firm_changed(firm)
+      index_firm(firm)
+    end
 
-  def self.handle_aggregate_changed(aggregate)
-    index_firm(aggregate.firm) if firm_exists?(aggregate.firm)
-  end
+    def handle_aggregate_changed(aggregate)
+      index_firm(aggregate.firm) if firm_exists?(aggregate.firm)
+    end
 
-  def self.store_firm(firm)
-    FirmRepository.new.store(firm)
-  end
+    def store_firm(firm)
+      FirmRepository.new.store(firm)
+    end
 
-  def self.delete_firm(firm)
-    FirmRepository.new.delete(firm.id)
-  end
+    def delete_firm(firm)
+      FirmRepository.new.delete(firm.id)
+    end
 
-  def self.firm_exists?(firm)
-    return false if (firm.nil? || firm.destroyed?)
-    Firm.exists?(firm.id)
+    def firm_exists?(firm)
+      return false if (firm.nil? || firm.destroyed?)
+      Firm.exists?(firm.id)
+    end
   end
 end

--- a/spec/jobs/index_firm_job_spec.rb
+++ b/spec/jobs/index_firm_job_spec.rb
@@ -1,36 +1,8 @@
 RSpec.describe IndexFirmJob, '#perform' do
-  let(:repository) { instance_double(FirmRepository) }
-  let(:firm_id) { 3 }
-  let(:firm) { Firm.new(id: firm_id) }
+  let(:firm) { Firm.new }
 
-  before do
-    allow(FirmRepository).to receive(:new).and_return(repository)
-  end
-
-  context 'when firm is publishable' do
-    before do
-      allow(firm).to receive(:publishable?).and_return(true)
-    end
-
-    it 'delegates to the firm repository' do
-      expect(repository).to receive(:store).with(firm)
-      described_class.new.perform(firm)
-    end
-  end
-
-  context 'when firm is not publishable' do
-    before do
-      allow(firm).to receive(:publishable?).and_return(false)
-    end
-
-    it 'does not delegates to the firm repository' do
-      expect(repository).not_to receive(:store).with(firm)
-      described_class.new.perform(firm)
-    end
-
-    it 'invokes the DeleteFirmJob to remove the firm from the directory' do
-      expect(DeleteFirmJob).to receive(:perform_later).with(firm_id)
-      described_class.new.perform(firm)
-    end
+  it 'delegates to the firm indexer' do
+    expect(FirmIndexer).to receive(:index_firm).with(firm)
+    described_class.new.perform(firm)
   end
 end

--- a/spec/lib/mas/firm_indexer_spec.rb
+++ b/spec/lib/mas/firm_indexer_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe FirmIndexer do
   end
 
   describe '#handle_firm_changed' do
-    let(:firm) { FactoryGirl.create(:firm) }
+    let(:handle_firm_changed) { described_class.method(:handle_firm_changed) }
+    let(:index_firm) { described_class.method(:index_firm) }
 
     it 'delegates to #index_firm' do
-      expect(described_class).to receive(:index_firm).with(firm)
-      described_class.handle_firm_changed(firm)
+      expect(handle_firm_changed).to eq(index_firm)
     end
   end
 

--- a/spec/lib/mas/firm_indexer_spec.rb
+++ b/spec/lib/mas/firm_indexer_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe FirmIndexer do
     expect(firm_repo_instance).to receive(:delete).with(firm.id)
   end
 
+  def expect_no_action
+    expect(firm_repo_instance).to receive(:store).with(firm).exactly(0).times
+    expect(firm_repo_instance).to receive(:delete).with(firm.id).exactly(0).times
+  end
+
   describe '#index_firm' do
     subject { described_class.index_firm(firm) }
     let(:firm) { FactoryGirl.create(:publishable_firm) }
@@ -47,6 +52,63 @@ RSpec.describe FirmIndexer do
     it 'delegates to #index_firm' do
       expect(described_class).to receive(:index_firm).with(firm)
       described_class.handle_firm_changed(firm)
+    end
+  end
+
+  describe '#handle_aggregate_changed' do
+    let(:firm) { FactoryGirl.create(:firm_with_offices) }
+    let!(:aggregate) { firm.offices.first }
+    subject { described_class.handle_aggregate_changed(aggregate) }
+
+    context 'when the aggregate record has changed' do
+      it 'stores the firm in the index' do
+        aggregate.update!(address_line_one: 'A change of address')
+        expect_store
+        subject
+      end
+    end
+
+    context 'when the aggregate record has been destroyed' do
+      it 'stores the firm in the index' do
+        aggregate.destroy
+        expect_store
+        subject
+      end
+    end
+
+    context 'when the aggregate record\'s firm has been destroyed' do
+      it 'does nothing' do
+        firm.destroy
+        expect_no_action
+        subject
+      end
+    end
+  end
+
+  describe '#firm_exists?' do
+    subject { described_class.firm_exists?(firm) }
+    let(:firm) { FactoryGirl.create(:firm) }
+
+    context 'when the firm instance and db record exist' do
+      it { is_expected.to be(true) }
+    end
+
+    context 'when nil passed' do
+      let(:firm) { nil }
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the firm instance has been destroyed' do
+      before { firm.destroy }
+      it { is_expected.to be(false) }
+    end
+
+    context 'when another instance of this firm has been destroyed' do
+      let(:firm) { FactoryGirl.create(:firm) }
+      let(:other_instance) { Firm.find(firm.id) }
+
+      before { other_instance.destroy }
+      it { is_expected.to be(false) }
     end
   end
 end

--- a/spec/lib/mas/firm_indexer_spec.rb
+++ b/spec/lib/mas/firm_indexer_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe FirmIndexer do
 
   describe '#index_firm' do
     subject { described_class.index_firm(firm) }
+    let(:firm) { FactoryGirl.create(:publishable_firm) }
 
     context 'when the firm is publishable' do
-      let(:firm) { FactoryGirl.create(:publishable_firm) }
-
       it 'stores the firm in the index' do
         expect_store
         subject
@@ -32,26 +31,6 @@ RSpec.describe FirmIndexer do
         subject
       end
     end
-  end
-
-  describe '#handle_firm_changed' do
-    let(:firm) { FactoryGirl.create(:firm) }
-    subject { described_class.handle_firm_changed(firm) }
-
-    context 'when the firm has been created' do
-      it 'indexes the firm' do
-        expect_store
-        subject
-      end
-    end
-
-    context 'when the firm has been updated' do
-      it 'indexes the firm' do
-        firm.update!(registered_name: 'hello')
-        expect_store
-        subject
-      end
-    end
 
     context 'when the firm has been destroyed' do
       it 'deletes the firm from the index' do
@@ -59,6 +38,15 @@ RSpec.describe FirmIndexer do
         firm.destroy
         subject
       end
+    end
+  end
+
+  describe '#handle_firm_changed' do
+    let(:firm) { FactoryGirl.create(:firm) }
+
+    it 'delegates to #index_firm' do
+      expect(described_class).to receive(:index_firm).with(firm)
+      described_class.handle_firm_changed(firm)
     end
   end
 end

--- a/spec/lib/mas/firm_indexer_spec.rb
+++ b/spec/lib/mas/firm_indexer_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe FirmIndexer do
+  let(:firm_repo_instance) { double }
+  before do
+    allow(FirmRepository).to receive(:new).and_return(firm_repo_instance)
+  end
+
+  describe '#index_firm' do
+    subject { described_class.index_firm(firm) }
+
+    context 'when the firm is publishable' do
+      let(:firm) { FactoryGirl.create(:publishable_firm) }
+
+      it 'stores the firm in the index' do
+        expect(firm_repo_instance).to receive(:store).with(firm)
+        subject
+      end
+    end
+
+    context 'when the firm is not publishable' do
+      let(:firm) { FactoryGirl.create(:firm_without_offices, :without_advisers) }
+
+      it 'attempts to remove the firm from the index in case it was previously published' do
+        expect(firm_repo_instance).to receive(:delete).with(firm.id)
+        subject
+      end
+    end
+  end
+end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe Adviser do
 
     context 'when the subject is destroyed' do
       before do
+        allow(FirmIndexer).to receive(:handle_aggregate_changed)
         adviser.destroy
         adviser.run_callbacks(:commit)
       end
@@ -148,8 +149,9 @@ RSpec.describe Adviser do
         expect(queue_contains_a_job_for(GeocodeAdviserJob)).to be_falsey
       end
 
-      it 'the adviser\'s firm is scheduled for geocoding/indexing' do
-        expect(queue_contains_a_job_for(GeocodeFirmJob)).to be_truthy
+      # TODO Temporary patch up code to make the tests pass
+      it 'the adviser notifies the firm indexer that it has changed' do
+        expect(FirmIndexer).to have_received(:handle_aggregate_changed).with(adviser)
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR introduces a home for the logic relating to indexing firms. In the existing system this was spread around between advisers, firms and the geocoding jobs and the index firm job.

The `FirmIndexer` (for want of a better name) is now *THE* only thing that knows the logic about when and how a firm is indexed to ElasticSearch. The models simplify notify it in `on_commit` handlers that something has changed and it then works out the required outcome from what it gets given.

## Consequences

At this point indexing is no longer done on an ActiveJob. We could easily put this back in (which is why I've not deleted the job classes in this PR), but we need to prove that doing this on a background job is actually necessary.

## Next work

* The `Adviser` has not yet been fully converted over. That will be done next.
* The `Firm` still has lat/long fields, includes Geocodable, and delegates address fields to main office. This needs to be taken out.
* I'd feel more comfortable if we had a integration test that exercises a few of the indexing/geocoding scenarios end to end.
* We need to expose the office coordinates to ElasticSearch.
* We need to think about migrating existing geo data from firms to the main offices.