### PR TITLE
[DEV APPROVED] Update Adviser model to use new geocoding and indexing code

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -85,7 +85,7 @@ class Adviser < ActiveRecord::Base
   end
 
   def reindex_old_firm
-    IndexFirmJob.perform_later(Firm.find(@old_firm_id)) if @old_firm_id.present?
+    Firm.find(@old_firm_id).notify_indexer if @old_firm_id.present?
     @old_firm_id = nil
   end
 

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -1,5 +1,6 @@
 class Adviser < ActiveRecord::Base
   include Geocodable
+  include GeocodableSync
 
   attr_reader :old_firm_id
 
@@ -51,6 +52,14 @@ class Adviser < ActiveRecord::Base
 
   def full_street_address
     "#{postcode}, United Kingdom"
+  end
+
+  def has_address_changes?
+    changed_attributes.include? :postcode
+  end
+
+  def add_geocoding_failed_error
+    errors.add(:address, I18n.t("#{model_name.i18n_key}.geocoding.failure_message"))
   end
 
   def field_order

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -35,7 +35,12 @@ class Adviser < ActiveRecord::Base
   scope :sorted_by_name, -> { order(:name) }
 
   after_save :flag_changes_for_after_commit
+  after_commit :notify_indexer
   after_commit :reindex_old_firm
+
+  def notify_indexer
+    FirmIndexer.handle_aggregate_changed(self)
+  end
 
   def self.on_firms_with_fca_number(fca_number)
     firms = Firm.where(fca_number: fca_number)

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -31,10 +31,10 @@ class Adviser < ActiveRecord::Base
 
   validate :match_reference_number
 
-  after_save :flag_changes_for_after_commit
-  after_commit :geocode_and_reindex_firm
-  after_commit :reindex_old_firm
   scope :sorted_by_name, -> { order(:name) }
+
+  after_save :flag_changes_for_after_commit
+  after_commit :reindex_old_firm
 
   def self.on_firms_with_fca_number(fca_number)
     firms = Firm.where(fca_number: fca_number)
@@ -68,15 +68,6 @@ class Adviser < ActiveRecord::Base
   # this we flag any important changes here to be actioned later.
   def flag_changes_for_after_commit
     @old_firm_id = firm_id_change.first if firm_id_changed?
-  end
-
-  def geocode_and_reindex_firm
-    if destroyed?
-      # TODO Temporary patch up code to make the tests pass
-      FirmIndexer.handle_aggregate_changed(self)
-    elsif valid?
-      GeocodeAdviserJob.perform_later(self)
-    end
   end
 
   def reindex_old_firm

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -107,41 +107,6 @@ RSpec.describe Adviser do
     let(:job_class) { GeocodeAdviserJob }
   end
 
-  describe 'after_commit :geocode_and_reindex' do
-    let(:adviser) { create(:adviser) }
-
-    context 'when the postcode is present' do
-      it 'the adviser is scheduled for geocoding' do
-        expect { adviser.run_callbacks(:commit) }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
-      end
-    end
-
-    context 'when the postcode is not valid' do
-      before { adviser.postcode = 'not-valid' }
-
-      it 'the adviser is not scheduled for geocoding' do
-        expect { adviser.run_callbacks(:commit) }.not_to change { ActiveJob::Base.queue_adapter.enqueued_jobs }
-      end
-    end
-
-    context 'when the subject is destroyed' do
-      before do
-        allow(FirmIndexer).to receive(:handle_aggregate_changed)
-        adviser.destroy
-        adviser.run_callbacks(:commit)
-      end
-
-      it 'the adviser is not scheduled for geocoding' do
-        expect(queue_contains_a_job_for(GeocodeAdviserJob)).to be_falsey
-      end
-
-      # TODO Temporary patch up code to make the tests pass
-      it 'the adviser notifies the firm indexer that it has changed' do
-        expect(FirmIndexer).to have_received(:handle_aggregate_changed).with(adviser)
-      end
-    end
-  end
-
   describe 'after_save :flag_changes_for_after_commit' do
     let(:original_firm) { create(:firm) }
     let(:receiving_firm) { create(:firm) }

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -107,6 +107,35 @@ RSpec.describe Adviser do
     let(:job_class) { GeocodeAdviserJob }
   end
 
+  it_should_behave_like 'synchronously geocodable' do
+    let(:invalid_geocodable) { Adviser.new }
+    let(:valid_new_geocodable) { FactoryGirl.build(:adviser) }
+    let(:saved_geocodable) { FactoryGirl.create(:adviser) }
+    let(:address_field_name) { :postcode }
+    let(:address_field_updated_value) { 'S032 2AY' }
+    let(:updated_address_params) { { address_field_name => address_field_updated_value } }
+  end
+
+  describe '#has_address_changes?' do
+    subject { FactoryGirl.create(:adviser) }
+
+    context 'when none of the address fields have changed' do
+      it 'returns false' do
+        expect(subject.has_address_changes?).to be(false)
+      end
+    end
+
+    context "when the model postcode field has changed" do
+      before do
+        subject.postcode = 'S032 2AY'
+      end
+
+      it 'returns true' do
+        expect(subject.has_address_changes?).to be(true)
+      end
+    end
+  end
+
   describe 'after_save :flag_changes_for_after_commit' do
     let(:original_firm) { create(:firm) }
     let(:receiving_firm) { create(:firm) }

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -136,6 +136,15 @@ RSpec.describe Adviser do
     end
   end
 
+  describe '#notify_indexer' do
+    subject { FactoryGirl.create(:adviser) }
+
+    it 'notifies the indexer that the office has changed' do
+      expect(FirmIndexer).to receive(:handle_aggregate_changed).with(subject)
+      subject.notify_indexer
+    end
+  end
+
   describe 'after_save :flag_changes_for_after_commit' do
     let(:original_firm) { create(:firm) }
     let(:receiving_firm) { create(:firm) }

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -5,20 +5,6 @@ RSpec.describe Adviser do
     clear_job_queue
   end
 
-  describe '#geocoded?' do
-    context 'when the adviser has lat/long' do
-      it 'is classed as geocoded' do
-        expect(build(:adviser)).to be_geocoded
-      end
-    end
-
-    context 'when the adviser does not have lat/long' do
-      it 'is not classed as geocoded' do
-        expect(build(:adviser, latitude: nil, longitude: nil)).to_not be_geocoded
-      end
-    end
-  end
-
   describe 'before validation' do
     context 'when a reference number is present' do
       let(:attributes) { attributes_for(:adviser) }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Office do
     let(:invalid_geocodable) { Office.new }
     let(:valid_new_geocodable) { FactoryGirl.build(:office, firm: firm) }
     let(:saved_geocodable) { office }
+    let(:address_field_name) { :address_postcode }
+    let(:address_field_updated_value) { 'S032 2AY' }
+    let(:updated_address_params) { { address_line_one: 'A new place' } }
   end
 
   describe '#notify_indexer' do

--- a/spec/support/shared_examples/geocodable_examples.rb
+++ b/spec/support/shared_examples/geocodable_examples.rb
@@ -70,4 +70,26 @@ RSpec.shared_examples 'geocodable' do
       end
     end
   end
+
+  describe '#geocoded?' do
+    context 'when the subject has lat/long' do
+      before do
+        subject.latitude, subject.longitude = [1.0, 1.0]
+      end
+
+      it 'is classed as geocoded' do
+        expect(subject.geocoded?).to be(true)
+      end
+    end
+
+    context 'when the subject does not have lat/long' do
+      before do
+        subject.latitude, subject.longitude = [nil, nil]
+      end
+
+      it 'is not classed as geocoded' do
+        expect(subject.geocoded?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/geocodable_sync_examples.rb
+++ b/spec/support/shared_examples/geocodable_sync_examples.rb
@@ -12,6 +12,10 @@ RSpec.shared_examples 'synchronously geocodable' do
     it { is_expected.to respond_to(:add_geocoding_failed_error) }
   end
 
+  def modify_address(subject)
+    subject.send("#{address_field_name}=", address_field_updated_value)
+  end
+
   describe '#geocode' do
     context 'when the subject is not valid' do
       subject { invalid_geocodable }
@@ -101,7 +105,7 @@ RSpec.shared_examples 'synchronously geocodable' do
             before do
               subject.coordinates = [1.0, 1.0]
               subject.save!
-              subject.address_postcode = 'SO31 1PY'
+              modify_address(subject)
               subject.geocode
             end
 
@@ -151,7 +155,7 @@ RSpec.shared_examples 'synchronously geocodable' do
 
       context 'when the model address fields have changed' do
         before do
-          subject.address_postcode = 'SO31 2AY'
+          modify_address(subject)
           expect(subject).to have_address_changes
         end
 
@@ -199,12 +203,12 @@ RSpec.shared_examples 'synchronously geocodable' do
   end
 
   describe '#update_with_geocoding' do
-    subject { saved_geocodable.update_with_geocoding(address_line_one: '123 xyz street') }
+    subject { saved_geocodable.update_with_geocoding(updated_address_params) }
 
     it 'updates the geocodable with new attributes' do
       allow(saved_geocodable).to receive(:save_with_geocoding)
       subject
-      expect(saved_geocodable.changed_attributes).to include(:address_line_one)
+      expect(saved_geocodable.changed_attributes).to include(updated_address_params.keys.first)
     end
 
     it 'calls #save_with_geocoding' do


### PR DESCRIPTION
Mixes GeocodableSync into Adviser and replaces existing index job wrangling with simple calls to the FirmIndexer.

This updates the Adviser so it behaves the same way as the Office does after PRs #121, #120 and #119.