### PR TITLE
Add investing booleans to firm result

### DIFF
--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -24,7 +24,9 @@ class FirmSerializer < ActiveModel::Serializer
     :investment_sizes,
     :in_person_advice_methods,
     :adviser_qualification_ids,
-    :adviser_accreditation_ids
+    :adviser_accreditation_ids,
+    :ethical_investing_flag,
+    :sharia_investing_flag
 
   has_many :advisers
   has_many :offices

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -19,7 +19,9 @@ class FirmResult
     :in_person_advice_methods,
     :investment_sizes,
     :adviser_accreditation_ids,
-    :adviser_qualification_ids
+    :adviser_qualification_ids,
+    :ethical_investing_flag,
+    :sharia_investing_flag
   ]
 
   TYPES_OF_ADVICE_FIELDS = [

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe FirmResult do
         'investment_sizes' => [1, 2],
         'adviser_accreditation_ids' => [5],
         'adviser_qualification_ids' => [3],
+        'ethical_investing_flag' => true,
+        'sharia_investing_flag' => false,
         'advisers' => [
           {
             '_id'      => 1,
@@ -97,6 +99,14 @@ RSpec.describe FirmResult do
 
     it 'maps the `free_initial_meeting`' do
       expect(subject.free_initial_meeting).to eq(true)
+    end
+
+    it 'maps the "ethical_investing_flag"' do
+      expect(subject.ethical_investing_flag).to eq(true)
+    end
+
+    it 'maps the "sharia_investing_flag"' do
+      expect(subject.sharia_investing_flag).to eq(false)
     end
 
     it 'maps the `minimum_fixed_fee`' do

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe FirmSerializer do
       expect(subject[:adviser_accreditation_ids]).to eql(firm.accreditation_ids)
     end
 
+    it 'exposes "ethical_investing_flag"' do
+      expect(subject[:ethical_investing_flag]).to eql(firm.ethical_investing_flag)
+    end
+
+    it 'exposes "sharia_investing_flag"' do
+      expect(subject[:sharia_investing_flag]).to eql(firm.sharia_investing_flag)
+    end
+
     describe 'advisers' do
       before { create(:adviser, firm: firm, latitude: nil, longitude: nil) }
 


### PR DESCRIPTION
This change enables the Sharia and Ethical investing flags to be serialised for elastic search, and also available in a `FirmResult`, which is the object that represents deserialised data from elastic search.