### PR TITLE
[DEV APPROVED] Geocode offices on postcode alone

### DIFF
--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -2,14 +2,6 @@ class Office < ActiveRecord::Base
   include Geocodable
   include GeocodableSync
 
-  ADDRESS_FIELDS = [
-    :address_line_one,
-    :address_line_two,
-    :address_town,
-    :address_county,
-    :address_postcode
-  ].freeze
-
   belongs_to :firm
 
   before_validation :upcase_postcode
@@ -69,11 +61,11 @@ class Office < ActiveRecord::Base
   end
 
   def full_street_address
-    [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
+    "#{address_postcode}, United Kingdom"
   end
 
   def has_address_changes?
-    ADDRESS_FIELDS.any? { |field| changed_attributes.include? field }
+    changed_attributes.include? :address_postcode
   end
 
   def add_geocoding_failed_error

--- a/spec/fixtures/vcr_cassettes/geocode-no-results.yml
+++ b/spec/fixtures/vcr_cassettes/geocode-no-results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=1000%20Fantasy%20Ave,%20Neverland,%20ABC%20123,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=XX1%201XX,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,34 +21,28 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 18 Feb 2015 13:23:38 GMT
+      - Tue, 10 Nov 2015 16:31:42 GMT
       Expires:
-      - Thu, 19 Feb 2015 13:23:38 GMT
+      - Wed, 11 Nov 2015 16:31:42 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
       - "*"
       Server:
       - mafe
+      Content-Length:
+      - '65'
       X-Xss-Protection:
       - 1; mode=block
       X-Frame-Options:
       - SAMEORIGIN
-      Alternate-Protocol:
-      - 80:quic,p=0.08
-      Accept-Ranges:
-      - none
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         {
            "results" : [],
            "status" : "ZERO_RESULTS"
         }
     http_version: 
-  recorded_at: Wed, 18 Feb 2015 13:23:38 GMT
+  recorded_at: Tue, 10 Nov 2015 16:31:42 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/geocode-one-result.yml
+++ b/spec/fixtures/vcr_cassettes/geocode-one-result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20London,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,43 +21,32 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 18 Feb 2015 13:23:38 GMT
+      - Tue, 10 Nov 2015 16:25:02 GMT
       Expires:
-      - Thu, 19 Feb 2015 13:23:38 GMT
+      - Wed, 11 Nov 2015 16:25:02 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
       - "*"
       Server:
       - mafe
+      Content-Length:
+      - '495'
       X-Xss-Protection:
       - 1; mode=block
       X-Frame-Options:
       - SAMEORIGIN
-      Alternate-Protocol:
-      - 80:quic,p=0.08
-      Accept-Ranges:
-      - none
-      Vary:
-      - Accept-Encoding
-      Transfer-Encoding:
-      - chunked
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: |
         {
            "results" : [
               {
                  "address_components" : [
                     {
-                       "long_name" : "120",
-                       "short_name" : "120",
-                       "types" : [ "street_number" ]
-                    },
-                    {
-                       "long_name" : "Holborn",
-                       "short_name" : "Holborn",
-                       "types" : [ "route" ]
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
                     },
                     {
                        "long_name" : "London",
@@ -78,37 +67,42 @@ http_interactions:
                        "long_name" : "United Kingdom",
                        "short_name" : "GB",
                        "types" : [ "country", "political" ]
-                    },
-                    {
-                       "long_name" : "EC1N 2TD",
-                       "short_name" : "EC1N 2TD",
-                       "types" : [ "postal_code" ]
                     }
                  ],
-                 "formatted_address" : "120 Holborn, London EC1N 2TD, UK",
+                 "formatted_address" : "London EC1N 2TD, UK",
                  "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5182639,
+                          "lng" : -0.1078729
+                       },
+                       "southwest" : {
+                          "lat" : 51.5173261,
+                          "lng" : -0.1094075
+                       }
+                    },
                     "location" : {
                        "lat" : 51.5180697,
                        "lng" : -0.1085203
                     },
-                    "location_type" : "ROOFTOP",
+                    "location_type" : "APPROXIMATE",
                     "viewport" : {
                        "northeast" : {
-                          "lat" : 51.51941868029149,
-                          "lng" : -0.107171319708498
+                          "lat" : 51.5191439802915,
+                          "lng" : -0.107291219708498
                        },
                        "southwest" : {
-                          "lat" : 51.51672071970849,
-                          "lng" : -0.109869280291502
+                          "lat" : 51.5164460197085,
+                          "lng" : -0.109989180291502
                        }
                     }
                  },
-                 "place_id" : "ChIJ1y3irE0bdkgRz3w__Q4S9sI",
-                 "types" : [ "street_address" ]
+                 "place_id" : "ChIJ5_7trE0bdkgRKFWaw55y3rM",
+                 "types" : [ "postal_code" ]
               }
            ],
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Wed, 18 Feb 2015 13:23:38 GMT
+  recorded_at: Tue, 10 Nov 2015 16:25:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/jobs/geocode_firm_job_spec.rb
+++ b/spec/jobs/geocode_firm_job_spec.rb
@@ -6,16 +6,12 @@ RSpec.describe GeocodeFirmJob do
   subject(:firm) { create(:firm) }
 
   before do
-    firm.main_office.update!(address_line_one: address_line_one,
-                             address_line_two: address_line_two,
-                             address_postcode: address_postcode)
+    firm.main_office.update!(address_postcode: address_postcode)
     firm.reload
   end
 
   describe '#perform' do
     context 'when the firm address can be geocoded' do
-      let(:address_line_one) { '120 Holborn' }
-      let(:address_line_two) { 'London' }
       let(:address_postcode) { 'EC1N 2TD' }
 
       subject do
@@ -36,9 +32,7 @@ RSpec.describe GeocodeFirmJob do
     end
 
     context 'when firm address cannot be geocoded' do
-      let(:address_line_one) { '1000 Fantasy Ave' }
-      let(:address_line_two) { 'Neverland' }
-      let(:address_postcode) { 'ABC 123' }
+      let(:address_postcode) { 'XX1 1XX' }
 
       subject do
         VCR.use_cassette('geocode-no-results') do

--- a/spec/lib/mas/model_geocoder_spec.rb
+++ b/spec/lib/mas/model_geocoder_spec.rb
@@ -1,26 +1,22 @@
 RSpec.describe ModelGeocoder do
   let(:model_class) do
     Class.new do
-      attr_accessor :address_line_one, :address_line_two, :address_postcode, :longitude, :latitude
+      attr_accessor :address_postcode, :longitude, :latitude
 
       def update_coordinates!(*args); end
 
       def full_street_address
-        [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
+        "#{address_postcode}, United Kingdom"
       end
     end
   end
 
   let(:model) do
     model_class.new.tap do |thing|
-      thing.address_line_one = address_line_one
-      thing.address_line_two = address_line_two
       thing.address_postcode = address_postcode
     end
   end
 
-  let(:address_line_one) { '120 Holborn' }
-  let(:address_line_two) { 'London' }
   let(:address_postcode) { 'EC1N 2TD' }
   let(:expected_coordinates) { [51.5180697, -0.1085203] }
 
@@ -34,9 +30,7 @@ RSpec.describe ModelGeocoder do
     end
 
     context 'when model address cannot be geocoded' do
-      let(:address_line_one) { '1000 Fantasy Ave' }
-      let(:address_line_two) { 'Neverland' }
-      let(:address_postcode) { 'ABC 123' }
+      let(:address_postcode) { 'XX1 1XX' }
 
       it 'returns nil' do
         VCR.use_cassette('geocode-no-results') do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -58,15 +58,13 @@ RSpec.describe Office do
       end
     end
 
-    described_class::ADDRESS_FIELDS.each do |field|
-      context "when the model #{field} field has changed" do
-        before do
-          subject.send("#{field}=", 'changed')
-        end
+    context "when the model address_postcode field has changed" do
+      before do
+        subject.address_postcode = 'changed'
+      end
 
-        it 'returns true' do
-          expect(subject.has_address_changes?).to be(true)
-        end
+      it 'returns true' do
+        expect(subject.has_address_changes?).to be(true)
       end
     end
   end
@@ -222,18 +220,6 @@ RSpec.describe Office do
   describe '#full_street_address' do
     subject { office.full_street_address }
 
-    it { is_expected.to eql "#{office.address_line_one}, #{office.address_line_two}, #{office.address_postcode}, United Kingdom"}
-
-    context 'when line two is nil' do
-      before { office.address_line_two = nil }
-
-      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
-    end
-
-    context 'when line two is an empty string' do
-      before { office.address_line_two = '' }
-
-      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
-    end
+    it { is_expected.to eql "#{office.address_postcode}, United Kingdom"}
   end
 end


### PR DESCRIPTION
After discussing with Phil and Seb a decision was made to geocode offices on postcode alone. The idea being to lower the chances of geocoding failures by reducing the number of variables that affect it.