### PR TITLE
Update index firm job

### DIFF
--- a/lib/mas/tasks/firms/index.rake
+++ b/lib/mas/tasks/firms/index.rake
@@ -5,7 +5,7 @@ namespace :firms do
     confirmation = STDIN.gets.chomp
     if confirmation.downcase == 'yes'
       puts 'Building firms index...'
-      Firm.registered.each { |f| IndexFirmJob.perform_later(f) }
+      Firm.registered.each { |f| f.notify_indexer }
       puts '...indexing done.'
     else
       puts 'Indexing aborted.'

--- a/lib/mas/tasks/firms/index.rake
+++ b/lib/mas/tasks/firms/index.rake
@@ -3,10 +3,17 @@ namespace :firms do
   task index: :environment do
     puts 'Do you want to index all existing firms? [type `yes` to confirm]'
     confirmation = STDIN.gets.chomp
+
     if confirmation.downcase == 'yes'
-      puts 'Building firms index...'
-      Firm.registered.each { |f| f.notify_indexer }
-      puts '...indexing done.'
+      print 'Building firms index: '
+
+      Firm.registered.each do |f|
+        f.notify_indexer
+        putc '.'
+      end
+
+      puts
+      puts 'Indexing done.'
     else
       puts 'Indexing aborted.'
     end

--- a/lib/mas/tasks/firms/index.rake
+++ b/lib/mas/tasks/firms/index.rake
@@ -1,7 +1,7 @@
 namespace :firms do
   desc 'Index all existing firms'
   task index: :environment do
-    puts 'Do you want to index all existing firms? [type `yes` to confirm]'
+    puts "Do you want to index all #{Firm.registered.count} indexable firms? [type `yes` to confirm]"
     confirmation = STDIN.gets.chomp
 
     if confirmation.downcase == 'yes'


### PR DESCRIPTION
Updated rake task to use new `Firm#notify_indexer` API and reformatted output to show progress indicator for extra comfort on production runs:

```
$ be rake firms:index
Do you want to index all 2817 indexable firms? [type `yes` to confirm]
yes
Building firms index: .................................................... (and so on) .....
Indexing done.
```