### PR TITLE
Go back to using whole address to geocode offices again

### DIFF
--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -2,6 +2,14 @@ class Office < ActiveRecord::Base
   include Geocodable
   include GeocodableSync
 
+  ADDRESS_FIELDS = [
+    :address_line_one,
+    :address_line_two,
+    :address_town,
+    :address_county,
+    :address_postcode
+  ].freeze
+
   belongs_to :firm
 
   before_validation :upcase_postcode
@@ -61,11 +69,11 @@ class Office < ActiveRecord::Base
   end
 
   def full_street_address
-    "#{address_postcode}, United Kingdom"
+    [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
   end
 
   def has_address_changes?
-    changed_attributes.include? :address_postcode
+    ADDRESS_FIELDS.any? { |field| changed_attributes.include? field }
   end
 
   def add_geocoding_failed_error

--- a/spec/fixtures/vcr_cassettes/geocode-no-results.yml
+++ b/spec/fixtures/vcr_cassettes/geocode-no-results.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=XX1%201XX,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=1000%20Fantasy%20Ave,%20Neverland,%20ABC%20123,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,28 +21,34 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 10 Nov 2015 16:31:42 GMT
+      - Wed, 18 Feb 2015 13:23:38 GMT
       Expires:
-      - Wed, 11 Nov 2015 16:31:42 GMT
+      - Thu, 19 Feb 2015 13:23:38 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
       - "*"
       Server:
       - mafe
-      Content-Length:
-      - '65'
       X-Xss-Protection:
       - 1; mode=block
       X-Frame-Options:
       - SAMEORIGIN
+      Alternate-Protocol:
+      - 80:quic,p=0.08
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: |
         {
            "results" : [],
            "status" : "ZERO_RESULTS"
         }
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 16:31:42 GMT
+  recorded_at: Wed, 18 Feb 2015 13:23:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/geocode-one-result.yml
+++ b/spec/fixtures/vcr_cassettes/geocode-one-result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=120%20Holborn,%20London,%20EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,32 +21,43 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 10 Nov 2015 16:25:02 GMT
+      - Wed, 18 Feb 2015 13:23:38 GMT
       Expires:
-      - Wed, 11 Nov 2015 16:25:02 GMT
+      - Thu, 19 Feb 2015 13:23:38 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
       - "*"
       Server:
       - mafe
-      Content-Length:
-      - '495'
       X-Xss-Protection:
       - 1; mode=block
       X-Frame-Options:
       - SAMEORIGIN
+      Alternate-Protocol:
+      - 80:quic,p=0.08
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
     body:
-      encoding: ASCII-8BIT
+      encoding: UTF-8
       string: |
         {
            "results" : [
               {
                  "address_components" : [
                     {
-                       "long_name" : "EC1N 2TD",
-                       "short_name" : "EC1N 2TD",
-                       "types" : [ "postal_code" ]
+                       "long_name" : "120",
+                       "short_name" : "120",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "Holborn",
+                       "short_name" : "Holborn",
+                       "types" : [ "route" ]
                     },
                     {
                        "long_name" : "London",
@@ -67,42 +78,37 @@ http_interactions:
                        "long_name" : "United Kingdom",
                        "short_name" : "GB",
                        "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
                     }
                  ],
-                 "formatted_address" : "London EC1N 2TD, UK",
+                 "formatted_address" : "120 Holborn, London EC1N 2TD, UK",
                  "geometry" : {
-                    "bounds" : {
-                       "northeast" : {
-                          "lat" : 51.5182639,
-                          "lng" : -0.1078729
-                       },
-                       "southwest" : {
-                          "lat" : 51.5173261,
-                          "lng" : -0.1094075
-                       }
-                    },
                     "location" : {
                        "lat" : 51.5180697,
                        "lng" : -0.1085203
                     },
-                    "location_type" : "APPROXIMATE",
+                    "location_type" : "ROOFTOP",
                     "viewport" : {
                        "northeast" : {
-                          "lat" : 51.5191439802915,
-                          "lng" : -0.107291219708498
+                          "lat" : 51.51941868029149,
+                          "lng" : -0.107171319708498
                        },
                        "southwest" : {
-                          "lat" : 51.5164460197085,
-                          "lng" : -0.109989180291502
+                          "lat" : 51.51672071970849,
+                          "lng" : -0.109869280291502
                        }
                     }
                  },
-                 "place_id" : "ChIJ5_7trE0bdkgRKFWaw55y3rM",
-                 "types" : [ "postal_code" ]
+                 "place_id" : "ChIJ1y3irE0bdkgRz3w__Q4S9sI",
+                 "types" : [ "street_address" ]
               }
            ],
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Tue, 10 Nov 2015 16:25:02 GMT
+  recorded_at: Wed, 18 Feb 2015 13:23:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/mas/model_geocoder_spec.rb
+++ b/spec/lib/mas/model_geocoder_spec.rb
@@ -1,22 +1,26 @@
 RSpec.describe ModelGeocoder do
   let(:model_class) do
     Class.new do
-      attr_accessor :address_postcode, :longitude, :latitude
+      attr_accessor :address_line_one, :address_line_two, :address_postcode, :longitude, :latitude
 
       def update_coordinates!(*args); end
 
       def full_street_address
-        "#{address_postcode}, United Kingdom"
+        [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
       end
     end
   end
 
   let(:model) do
     model_class.new.tap do |thing|
+      thing.address_line_one = address_line_one
+      thing.address_line_two = address_line_two
       thing.address_postcode = address_postcode
     end
   end
 
+  let(:address_line_one) { '120 Holborn' }
+  let(:address_line_two) { 'London' }
   let(:address_postcode) { 'EC1N 2TD' }
   let(:expected_coordinates) { [51.5180697, -0.1085203] }
 
@@ -30,7 +34,9 @@ RSpec.describe ModelGeocoder do
     end
 
     context 'when model address cannot be geocoded' do
-      let(:address_postcode) { 'XX1 1XX' }
+      let(:address_line_one) { '1000 Fantasy Ave' }
+      let(:address_line_two) { 'Neverland' }
+      let(:address_postcode) { 'ABC 123' }
 
       it 'returns nil' do
         VCR.use_cassette('geocode-no-results') do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -58,13 +58,15 @@ RSpec.describe Office do
       end
     end
 
-    context "when the model address_postcode field has changed" do
-      before do
-        subject.address_postcode = 'changed'
-      end
+    described_class::ADDRESS_FIELDS.each do |field|
+      context "when the model #{field} field has changed" do
+        before do
+          subject.send("#{field}=", 'changed')
+        end
 
-      it 'returns true' do
-        expect(subject.has_address_changes?).to be(true)
+        it 'returns true' do
+          expect(subject.has_address_changes?).to be(true)
+        end
       end
     end
   end
@@ -220,6 +222,18 @@ RSpec.describe Office do
   describe '#full_street_address' do
     subject { office.full_street_address }
 
-    it { is_expected.to eql "#{office.address_postcode}, United Kingdom"}
+    it { is_expected.to eql "#{office.address_line_one}, #{office.address_line_two}, #{office.address_postcode}, United Kingdom"}
+
+    context 'when line two is nil' do
+      before { office.address_line_two = nil }
+
+      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
+    end
+
+    context 'when line two is an empty string' do
+      before { office.address_line_two = '' }
+
+      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
+    end
   end
 end


### PR DESCRIPTION
Reverts most of #127.

The problem we're solving here is this: if firm offices and advisers have the same postcode then the map pins for offices and advisers get plotted on top of each other.

What we found yesterday is that by geocoding offices on the full address, this introduces enough *fuzz* that most offices end up being plotted in a different place, which is enough to work around the problem acceptably. E.g.

![pasted image at 2015_11_12 04_48 pm](https://cloud.githubusercontent.com/assets/306583/11145983/34bdfc3e-8a02-11e5-96f1-d59c6b1dfa80.png)

Now becomes:

![pasted image at 2015_11_12 04_47 pm](https://cloud.githubusercontent.com/assets/306583/11145987/43ae7a3e-8a02-11e5-8e19-a003f20113ac.png)
