### PR TITLE
Change the geocoding errors key to 'geocoding' for clarity

### DIFF
--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -64,7 +64,7 @@ class Adviser < ActiveRecord::Base
   end
 
   def add_geocoding_failed_error
-    errors.add(:address, I18n.t("#{model_name.i18n_key}.geocoding.failure_message"))
+    errors.add(:geocoding, I18n.t("#{model_name.i18n_key}.geocoding.failure_message"))
   end
 
   def field_order

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -69,7 +69,7 @@ class Office < ActiveRecord::Base
   end
 
   def add_geocoding_failed_error
-    errors.add(:address, I18n.t("#{model_name.i18n_key}.geocoding.failure_message"))
+    errors.add(:geocoding, I18n.t("#{model_name.i18n_key}.geocoding.failure_message"))
   end
 
   private

--- a/spec/support/shared_examples/geocodable_sync_examples.rb
+++ b/spec/support/shared_examples/geocodable_sync_examples.rb
@@ -94,7 +94,7 @@ RSpec.shared_examples 'synchronously geocodable' do
 
           it 'adds an error to subject.errors' do
             subject.geocode
-            expect(subject.errors).to have_key(:address)
+            expect(subject.errors).to have_key(:geocoding)
           end
 
           it 'returns false' do


### PR DESCRIPTION
(@Tr4pSt3R This is the change we talked about on https://github.com/moneyadviceservice/rad/pull/324 yesterday. Do you approve?)

This should make it clearer on the `rad` app that we are dealing with errors from the geocoding stage. `address` was a bit vague. A related branch will be raised in `rad` to integrate this change.

