### PR TITLE
Bypass reference number check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.95)
+    mas-rad_core (0.0.96)
       active_model_serializers
       geocoder
       httpclient
@@ -119,7 +119,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    redis (3.2.1)
+    redis (3.2.2)
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.2.3)
@@ -174,4 +174,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -93,7 +93,7 @@ class Adviser < ActiveRecord::Base
   end
 
   def assign_name
-    self.name = Lookup::Adviser.find_by(
+    self.name = self.name || Lookup::Adviser.find_by(
       reference_number: reference_number
     ).try(:name)
   end

--- a/app/models/adviser.rb
+++ b/app/models/adviser.rb
@@ -27,9 +27,9 @@ class Adviser < ActiveRecord::Base
     uniqueness: true,
     format: {
       with: /\A[A-Z]{3}[0-9]{5}\z/
-    }
+    }, unless: :bypass_reference_number_check?
 
-  validate :match_reference_number
+  validate :match_reference_number, unless: :bypass_reference_number_check?
 
   scope :sorted_by_name, -> { order(:name) }
 

--- a/db/migrate/20160205150033_add_bypass_reference_number_check_to_advisers.rb
+++ b/db/migrate/20160205150033_add_bypass_reference_number_check_to_advisers.rb
@@ -1,0 +1,5 @@
+class AddBypassReferenceNumberCheckToAdvisers < ActiveRecord::Migration
+  def change
+    add_column :advisers, :bypass_reference_number_check, :boolean, default: false
+  end
+end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.95'
+    VERSION = '0.0.96'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111132037) do
+ActiveRecord::Schema.define(version: 20160205150033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,15 +31,16 @@ ActiveRecord::Schema.define(version: 20151111132037) do
   add_index "accreditations_advisers", ["adviser_id", "accreditation_id"], name: "advisers_accreditations_index", unique: true, using: :btree
 
   create_table "advisers", force: :cascade do |t|
-    t.string   "reference_number",              null: false
-    t.string   "name",                          null: false
-    t.integer  "firm_id",                       null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.string   "postcode",         default: "", null: false
-    t.integer  "travel_distance",  default: 0,  null: false
+    t.string   "reference_number",                              null: false
+    t.string   "name",                                          null: false
+    t.integer  "firm_id",                                       null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.string   "postcode",                      default: "",    null: false
+    t.integer  "travel_distance",               default: 0,     null: false
     t.float    "latitude"
     t.float    "longitude"
+    t.boolean  "bypass_reference_number_check", default: false
   end
 
   create_table "advisers_professional_bodies", id: false, force: :cascade do |t|

--- a/spec/factories/adviser.rb
+++ b/spec/factories/adviser.rb
@@ -13,6 +13,7 @@ FactoryGirl.define do
     latitude  { Faker::Address.latitude.to_f.round(6) }
     longitude { Faker::Address.longitude.to_f.round(6) }
     firm factory: :firm_without_advisers
+    bypass_reference_number_check false
 
     after(:build) do |a, evaluator|
       if a.reference_number? && evaluator.create_linked_lookup_advisor

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -11,10 +11,24 @@ RSpec.describe Adviser do
         )
       end
 
-      it 'assigns #name from the lookup Adviser data' do
-        adviser.validate
+      context 'when a name is not present' do
+        before do
+          adviser.name = nil
+        end
 
-        expect(adviser.name).to eq('Mr. Welp')
+        it 'assigns #name from the lookup Adviser data' do
+          adviser.validate
+
+          expect(adviser.name).to eq('Mr. Welp')
+        end
+      end
+
+      context 'when a name is present' do
+        it 'does not override the existing name' do
+          adviser.validate
+
+          expect(adviser.name).not_to eq('Mr. Welp')
+        end
       end
     end
   end

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -1,10 +1,4 @@
 RSpec.describe Adviser do
-  include QueueSpecHelper
-
-  before do
-    clear_job_queue
-  end
-
   describe 'before validation' do
     context 'when a reference number is present' do
       let(:attributes) { attributes_for(:adviser) }

--- a/spec/models/adviser_spec.rb
+++ b/spec/models/adviser_spec.rb
@@ -51,39 +51,47 @@ RSpec.describe Adviser do
     end
 
     describe 'reference number' do
-      it 'is required' do
-        expect(build(:adviser, reference_number: nil)).to_not be_valid
-      end
-
-      it 'must be three characters and five digits exactly' do
-        %w(badtimes ABCDEFGH 8008135! 12345678).each do |bad|
-          Lookup::Adviser.create!(reference_number: bad, name: 'Mr. Derp')
-
-          expect(build(:adviser,
-                       reference_number: bad,
-                       create_linked_lookup_advisor: false)).to_not be_valid
+      context 'when `bypass_reference_number_check` is true' do
+        it 'is not required' do
+          expect(build(:adviser, bypass_reference_number_check: true, reference_number: nil)).to be_valid
         end
       end
 
-      it 'must be matched to the lookup data' do
-        build(:adviser, reference_number: 'ABC12345').tap do |a|
-          Lookup::Adviser.delete_all
-
-          expect(a).to_not be_valid
-        end
-      end
-
-      context 'when an adviser with the same reference number already exists' do
-        let(:reference_number) { 'ABC12345' }
-
-        before do
-          create(:adviser, reference_number: reference_number)
+      context 'when `bypass_reference_number_check` is false' do
+        it 'is required' do
+          expect(build(:adviser, reference_number: nil)).to_not be_valid
         end
 
-        it 'must not be valid' do
-          expect(build(:adviser,
-                       reference_number: reference_number,
-                       create_linked_lookup_advisor: false)).to_not be_valid
+        it 'must be three characters and five digits exactly' do
+          %w(badtimes ABCDEFGH 8008135! 12345678).each do |bad|
+            Lookup::Adviser.create!(reference_number: bad, name: 'Mr. Derp')
+
+            expect(build(:adviser,
+                         reference_number: bad,
+                         create_linked_lookup_advisor: false)).to_not be_valid
+          end
+        end
+
+        it 'must be matched to the lookup data' do
+          build(:adviser, reference_number: 'ABC12345').tap do |a|
+            Lookup::Adviser.delete_all
+
+            expect(a).to_not be_valid
+          end
+        end
+
+        context 'when an adviser with the same reference number already exists' do
+          let(:reference_number) { 'ABC12345' }
+
+          before do
+            create(:adviser, reference_number: reference_number)
+          end
+
+          it 'must not be valid' do
+            expect(build(:adviser,
+                         reference_number: reference_number,
+                         create_linked_lookup_advisor: false)).to_not be_valid
+          end
         end
       end
     end


### PR DESCRIPTION
> In some cases, we need to include advisers in the directory who do not have an adviser reference number for us to cross-check against the FCA Register.
>
> This is needed to be able to include equity release advisers who do not have a FCA adviser reference number.
>
> This does not need to be represented in self-service only manual entry by MAS.  This gives us the security that only qualified individuals are being added to directory.

Opening a WIP PR for this piece of work for visibility + comments.