### PR TITLE
Firm website URL format: make protocol prefix optional

### DIFF
--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -46,7 +46,7 @@ class Firm < ActiveRecord::Base
   validates :website_address,
     allow_blank: true,
     length: { maximum: 100 },
-    format: { with: /\Ahttps?:\/\/\S+\.\S+/ }
+    format: { with: /\A(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+/ }
 
   validates :free_initial_meeting,
     inclusion: { in: FREE_INITIAL_MEETING_VALID_VALUES }

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -179,12 +179,27 @@ RSpec.describe Firm do
           expect(build(:firm, website_address: "#{'a' * 100}.com")).not_to be_valid
         end
 
-        it 'must include the protocol segment' do
-          expect(build(:firm, website_address: 'www.google.com')).not_to be_valid
+        it 'must contain at least one .' do
+          expect(build(:firm, website_address: 'http://examplecom')).not_to be_valid
+          expect(build(:firm, website_address: 'http://example.com')).to be_valid
         end
 
-        it 'must be a reasonably valid URL' do
-          expect(build(:firm, website_address: 'http://a')).not_to be_valid
+        it 'must not contain spaces' do
+          expect(build(:firm, website_address: 'http://example site.com')).not_to be_valid
+        end
+
+        it 'does not require the protocol to be present' do
+          expect(build(:firm, website_address: 'www.example.com')).to be_valid
+        end
+
+        it 'must require the protocol to be http or https if provided' do
+          expect(build(:firm, website_address: 'http://www.example.com')).to be_valid
+          expect(build(:firm, website_address: 'https://www.example.com')).to be_valid
+          expect(build(:firm, website_address: 'ftp://www.example.com')).not_to be_valid
+        end
+
+        it 'allows paths to be in the address' do
+          expect(build(:firm, website_address: 'www.example.com/user')).to be_valid
         end
       end
     end


### PR DESCRIPTION
> if a firm enter their website address in the following format: www.mywebsite.com an error message displays stating the firm should enter the address using this format: http://www.mywebsite.com
>
> The sign-up process can be simplified by allowing firms to enter their website with this format:
> www.mywebsite.com

Related PRs https://github.com/moneyadviceservice/rad/pull/333 and https://github.com/moneyadviceservice/rad_consumer/pull/263

Relaxes the validation that is performed on the website address.