### PR TITLE
Modify FirmSerializer to serialize Firm#languages

### DIFF
--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -21,7 +21,8 @@ class FirmSerializer < ActiveModel::Serializer
     :adviser_qualification_ids,
     :adviser_accreditation_ids,
     :ethical_investing_flag,
-    :sharia_investing_flag
+    :sharia_investing_flag,
+    :languages
 
   has_many :advisers
   has_many :offices

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -113,5 +113,21 @@ RSpec.describe FirmSerializer do
         end
       end
     end
+
+    describe 'languages' do
+      context 'when languages have been selected' do
+        before { firm.languages = ['fra', 'deu'] }
+
+        it 'serializes them' do
+          expect(subject[:languages]).to eq(['fra', 'deu'])
+        end
+      end
+
+      context 'when no languages have been selected' do
+        it 'serializes an empty list' do
+          expect(subject[:languages]).to eq([])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# What?

Modification to serialize the `Firm#languages` array.

# Why?

This makes firms' languages available in ElasticSearch and therefore means we can surface this data on the RAD directory.

# Background

In the last phase of the RAD we added the ability for firms to specify any non-English languages they can provide their service using. This change is in preparation for showing this information on the consumer facing directory.