### PR TITLE
Get languages back out of ElasticSearch

### DIFF
--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -21,7 +21,8 @@ class FirmResult
     :adviser_accreditation_ids,
     :adviser_qualification_ids,
     :ethical_investing_flag,
-    :sharia_investing_flag
+    :sharia_investing_flag,
+    :languages
   ]
 
   TYPES_OF_ADVICE_FIELDS = [

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe FirmResult do
         'adviser_qualification_ids' => [3],
         'ethical_investing_flag' => true,
         'sharia_investing_flag' => false,
+        'languages' => %w(spa por aae),
         'advisers' => [
           {
             '_id'      => 1,
@@ -120,6 +121,10 @@ RSpec.describe FirmResult do
 
     it 'maps the "sharia_investing_flag"' do
       expect(subject.sharia_investing_flag).to eq(false)
+    end
+
+    it 'maps the "languages"' do
+      expect(subject.languages).to eq(%w(spa por aae))
     end
 
     it 'maps the `minimum_fixed_fee`' do


### PR DESCRIPTION
# What?

Adds the `languages` attribute on the `FirmResult` so that the array of languages are read out of the JSON returned by ElasticSearch.

# Why?

Now that a [firm's spoken languages are serialised to ElasticSearch](https://github.com/moneyadviceservice/mas-rad_core/pull/140) when they save their record, we need a way to get them back out so we can show them in `rad_consumer`.