### PR TITLE
Fixes the query methods not being executed

### DIFF
--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -20,7 +20,7 @@ class Snapshot < ActiveRecord::Base
   # 3. For each of those, find the related attribute (remove the 'query_' from the method name)
   # 4. Run the query method, count the return value, and set that to the related attribute
   def run_queries
-    public_methods(false)
+    public_methods
       .select { |method| method.to_s.starts_with?('query_') }
       .each do |query_method|
         related_attribute = query_method.to_s.sub('query_', '')

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -15,17 +15,14 @@ class Snapshot < ActiveRecord::Base
     @_publishable_firms ||= Firm.registered.select(&:publishable?)
   end
 
-  # 1. Gets all public methods
-  # 2. Filters those to only include methods beginning with 'query_'
-  # 3. For each of those, find the related attribute (remove the 'query_' from the method name)
-  # 4. Run the query method, count the return value, and set that to the related attribute
+  # 1. Gets all metric fields
+  # 2. For each of those, find the related query
+  # 3. Run the query method, count the return value, and set the metric
   def run_queries
-    public_methods
-      .select { |method| method.to_s.starts_with?('query_') }
-      .each do |query_method|
-        related_attribute = query_method.to_s.sub('query_', '')
-        result = send(query_method)
-        send("#{related_attribute}=", result.count)
-      end
+    metrics_in_order.each do |metric|
+      query_method = "query_#{metric}"
+      result = send(query_method)
+      self[metric] = result.count
+    end
   end
 end

--- a/spec/models/snapshot_spec.rb
+++ b/spec/models/snapshot_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe Snapshot do
 
   describe '#save_and_run' do
     it 'runs all queries and sets the count of their result' do
-      query_methods = subject.public_methods(false).select { |m| m.to_s.starts_with?('query_') }
-      query_methods.each_with_index do |m, i|
-        allow(subject).to receive(m).and_return(Array.new(i))
+      query_methods = subject.metrics_in_order.map { |metric| "query_#{metric}" }
+      query_methods.each_with_index do |query_method, index|
+        allow(subject).to receive(query_method).and_return(Array.new(index))
       end
 
       subject.run_queries_and_save
 
-      query_methods.each_with_index do |m, i|
-        attr = m.to_s.sub('query_', '').to_sym
-        expect(subject.send(attr)).to eq(i)
+      subject.metrics_in_order.each_with_index do |metric, index|
+        expect(subject.send(metric)).to eq(index)
       end
     end
   end


### PR DESCRIPTION
After moving the query methods to modules, `public_methods(false)` was no longer returning those methods. This snuck in because the specs stub these methods out, and I made the mistake of not checking it in the browser.