### PR TITLE
[DEV APPROVED] Remove "Other" accreditation: data migration

### DIFF
--- a/db/migrate/20160222091312_remove_other_accreditation.rb
+++ b/db/migrate/20160222091312_remove_other_accreditation.rb
@@ -7,6 +7,13 @@ class RemoveOtherAccreditation < ActiveRecord::Migration
   end
 
   def down
-    fail ActiveRecord::IrreversibleMigration
+    # Unfortunately we can't just insert the 'Other' record, as there are parts
+    # of `rad` and `rad_consumer` which rely on the 'Other' record having the
+    # ID of '5'. This is due to translations and configuring whether or not to
+    # show the record.
+    #
+    # You're allowed to roll back this migration, but be aware that if you're
+    # using an older version of `rad` or `rad_consumer` they may throw errors
+    # if this record doesn't exist.
   end
 end

--- a/db/migrate/20160222091312_remove_other_accreditation.rb
+++ b/db/migrate/20160222091312_remove_other_accreditation.rb
@@ -1,0 +1,12 @@
+class RemoveOtherAccreditation < ActiveRecord::Migration
+  class Accreditation < ActiveRecord::Base
+  end
+
+  def up
+    Accreditation.where(name: 'Other').destroy_all
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160211161127) do
+ActiveRecord::Schema.define(version: 20160222091312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Related PRs: https://github.com/moneyadviceservice/rad/pull/342 and https://github.com/moneyadviceservice/rad_consumer/pull/271

Was originally in https://github.com/moneyadviceservice/rad/pull/342 but as @munckymagik pointed out it should probably live in `mas-rad_core`.