### PR TITLE
[DEV APPROVED]Fix telephone validation: changes to the model 

### DIFF
--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -61,8 +61,9 @@ class Office < ActiveRecord::Base
     ]
   end
 
-  def telephone_number
-    super.try { |x| x.gsub(' ', '') }
+  def telephone_number=(new_phone_number)
+    return super if new_phone_number.nil?
+    super new_phone_number.gsub(/\s+/, ' ').strip
   end
 
   def full_street_address

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -60,8 +60,11 @@ class Office < ActiveRecord::Base
   end
 
   def telephone_number=(new_phone_number)
-    return super if new_phone_number.nil?
-    super new_phone_number.gsub(/\s+/, ' ').strip
+    super cleanup_telephone_number(new_phone_number)
+  end
+
+  def telephone_number
+    return format_telephone_number(cleanup_telephone_number(super))
   end
 
   def full_street_address
@@ -99,5 +102,13 @@ class Office < ActiveRecord::Base
     if telephone_number.nil? || !UKPhoneNumbers.valid?(telephone_number.gsub(' ', ''))
       errors.add(:telephone_number, I18n.t("#{model_name.i18n_key}.telephone_number.invalid_format"))
     end
+  end
+
+  def cleanup_telephone_number(telephone_number)
+    telephone_number.try { |t| t.gsub(/\s+/, ' ').strip }
+  end
+
+  def format_telephone_number(telephone_number)
+    telephone_number.try { |t| UKPhoneNumbers.format(t) || t }
   end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,4 +1,5 @@
 require 'uk_postcode'
+require 'uk_phone_numbers'
 
 class Office < ActiveRecord::Base
   include Geocodable
@@ -18,10 +19,7 @@ class Office < ActiveRecord::Base
     length: { maximum: 50 },
     format: { with: /.+@.+\..+/ }
 
-  validates :telephone_number,
-    presence: false,
-    length: { maximum: 30 },
-    format: { with: /\A[0-9 ]+\z/ }
+  validate :telephone_number_is_valid
 
   validates :address_line_one,
     presence: true,
@@ -96,5 +94,10 @@ class Office < ActiveRecord::Base
       errors.add(:address_postcode, 'is invalid')
     end
   end
-end
 
+  def telephone_number_is_valid
+    if telephone_number.nil? || !UKPhoneNumbers.valid?(telephone_number.gsub(' ', ''))
+      errors.add(:telephone_number, I18n.t("#{model_name.i18n_key}.telephone_number.invalid_format"))
+    end
+  end
+end

--- a/lib/mas/office_result.rb
+++ b/lib/mas/office_result.rb
@@ -15,10 +15,4 @@ class OfficeResult
     @disabled_access  = data['disabled_access']
     @location = Location.new data['location']['lat'], data['location']['lon']
   end
-
-  def telephone_number
-    return nil unless @telephone_number
-
-    UKPhoneNumbers.format(@telephone_number)
-  end
 end

--- a/spec/factories/office.rb
+++ b/spec/factories/office.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     address_county { Faker::Address.state }
     address_postcode 'EC1N 2TD'
     email_address { Faker::Internet.email }
-    telephone_number { Faker::Base.numerify('##### ### ###') }
+    telephone_number '07111 333 222'
     disabled_access { [true, false].sample }
     latitude  { Faker::Address.latitude.to_f.round(6) }
     longitude { Faker::Address.longitude.to_f.round(6) }

--- a/spec/factories/principal.rb
+++ b/spec/factories/principal.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     last_name { Faker::Name.last_name }
     email_address { Faker::Internet.email(first_name) }
     job_title { Faker::Name.title }
-    telephone_number { Faker::Base.numerify('##### ### ###') }
+    telephone_number '07111 333 222'
     confirmed_disclaimer true
 
     after(:build) { |p| create(:lookup_firm, fca_number: p.fca_number) }

--- a/spec/lib/mas/office_result_spec.rb
+++ b/spec/lib/mas/office_result_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe OfficeResult do
       'address_county'   => 'Cumbria',
       'address_postcode' => 'LA8 9BE',
       'email_address'    => 'postie@example.com',
-      'telephone_number' => '02085952346',
+      'telephone_number' => '020 8595 2346',
       'disabled_access'  => true,
       'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 }
     }

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -89,6 +89,33 @@ RSpec.describe Office do
     end
   end
 
+  describe '#telephone_number' do
+    context 'when `nil`' do
+      before { office.telephone_number = nil }
+
+      it 'returns `nil`' do
+        expect(office.telephone_number).to be_nil
+      end
+    end
+
+    context 'when provided' do
+      it 'removes whitespace from the front and back' do
+        office.update_column(:telephone_number, ' 07715 930 457  ')
+        expect(office.telephone_number).to eq('07715 930 457')
+      end
+
+      it 'removes extraneous whitespace' do
+        office.update_column(:telephone_number, '07715    930    457')
+        expect(office.telephone_number).to eq('07715 930 457')
+      end
+
+      it 'formats if there is no whitespace at all' do
+        office.update_column(:telephone_number, '07715930457')
+        expect(office.telephone_number).to eq('07715 930457')
+      end
+    end
+  end
+
   describe 'validation' do
     it 'is valid with valid attributes' do
       expect(office).to be_valid

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -118,21 +118,71 @@ RSpec.describe Office do
     end
 
     describe 'telephone number' do
-      context 'when not present' do
-        before { office.telephone_number = nil }
+      # See http://www.area-codes.org.uk/formatting.php#programmers for background info
 
-        it { is_expected.to_not be_valid }
+      context 'invalid inputs' do
+        context 'when not present' do
+          before { office.telephone_number = nil }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the input characters other than spaces or numbers' do
+          before { office.telephone_number = 'not-numbers-or-spaces' }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the area code is not specified' do
+          before { office.telephone_number = '917561' }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the prefix is not a 0' do
+          before { office.telephone_number = '7816917560' }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the prefix is not a real area code' do
+          # Currently 04 and 06 are not valid prefixes
+          before { office.telephone_number = '04816 917560' }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the prefix is a +nn country code' do
+          before { office.telephone_number = '+44 7816917560' }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the prefix is a 00nn international access code' do
+          before { office.telephone_number = '0044 7816917560' }
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context 'when the prefix is a nn international access code' do
+          before { office.telephone_number = '447816917560' }
+
+          it { is_expected.to_not be_valid }
+        end
       end
 
-      context 'when badly formatted' do
-        before { office.telephone_number = 'not-valid' }
+      context 'valid inputs' do
+        context 'when it has no spaces' do
+          before { office.telephone_number = '07816917561' }
 
-        it { is_expected.to_not be_valid }
-      end
+          it { is_expected.to be_valid }
+        end
 
-      context 'length' do
-        specify { expect_length_of(office, :telephone_number, 30, fill_char: '0').to be_valid }
-        specify { expect_length_of(office, :telephone_number, 31, fill_char: '0').not_to be_valid }
+        context 'when it has spaces' do
+          before { office.telephone_number = '07816 917 561' }
+
+          it { is_expected.to be_valid }
+        end
       end
     end
 

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Office do
     end
   end
 
-  describe '#telephone_number' do
+  describe '#telephone_number=' do
     context 'when `nil`' do
       before { office.telephone_number = nil }
 
@@ -77,10 +77,14 @@ RSpec.describe Office do
     end
 
     context 'when provided' do
-      before { office.telephone_number = ' 07715 930 457  ' }
+      it 'removes whitespace from the front and back' do
+        office.telephone_number = ' 07715 930 457  '
+        expect(office.telephone_number).to eq('07715 930 457')
+      end
 
-      it 'removes whitespace' do
-        expect(office.telephone_number).to eq('07715930457')
+      it 'removes extraneous whitespace' do
+        office.telephone_number = '07715    930    457'
+        expect(office.telephone_number).to eq('07715 930 457')
       end
     end
   end


### PR DESCRIPTION
# What?

Tightens the validation rules for new telephone numbers on the Office model and centralises the clean up and formatting of phone numbers to the model.

# Why?

Previously it was possible to put in invalid numbers e.g.

```
4784529 <-- No area code
0208 <-- Just area code!
020804784529 <-- Spot the extra invalid digit?
     0208        4784529 <-- WT? Yes there were some like this.
442084784529 <-- an attempt at specifying an international dialling code
```

Now the number must be a valid UK telephone number including area code or a mobile number.

# The new rules

* Now the number must be valid according to the `uk_telephone_numbers` Gem which implements the rules stated here: http://www.area-codes.org.uk/formatting.php#programmers
* If the user has attempted to space their number in a way that is helpful for readability  then we prefer that (e.g. `0333 00 22 333` instead of `0333 002 2333`) otherwise we format using `uk_telephone_numbers`

# What about existing data?

* There are 9 records in the existing database that are not valid. We will manually clean them up. Until they are fixed they will simply show as-is on the directory.
* The remaining 3000+ are valid but a subset are not formatted exactly as we want just yet. We now have the choice to re-save all office records to correct that or let it happen naturally over time.