### PR TITLE
Added languages used method on firm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ spec/dummy/.sass-cache
 spec/dummy/config/*.yml
 bad_firms.csv
 *.todo
+.tags

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.103)
+    mas-rad_core (0.0.104)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/firm.rb
+++ b/app/models/firm.rb
@@ -17,6 +17,10 @@ class Firm < ActiveRecord::Base
   scope :registered, -> { where.not(REGISTERED_MARKER_FIELD => nil) }
   scope :sorted_by_registered_name, -> { order(:registered_name) }
 
+  def self.languages_used
+    pluck('DISTINCT unnest("languages")').sort
+  end
+
   has_and_belongs_to_many :in_person_advice_methods
   has_and_belongs_to_many :other_advice_methods
   has_and_belongs_to_many :initial_advice_fee_structures

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.103'
+    VERSION = '0.0.104'
   end
 end

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -1,6 +1,35 @@
 RSpec.describe Firm do
   subject(:firm) { build(:firm) }
 
+  describe 'languages_used' do
+    context 'when there are no firms' do
+      it 'has no languages' do
+        expect(Firm.languages_used).to be_empty
+      end
+    end
+
+    context 'when there are firms with no languages set' do
+      it 'has no languages' do
+        create(:firm, languages: [])
+        expect(Firm.languages_used).to be_empty
+      end
+    end
+
+    context 'when there are a multiple languages on multiple firms' do
+      it 'has has multiple languages' do
+        create(:firm, languages: ['sco', 'swe'])
+        create(:firm, languages: ['nor', 'lat'])
+        expect(Firm.languages_used).to eq(['lat', 'nor', 'sco', 'swe'])
+      end
+
+      it 'has has duplicate languages' do
+        create(:firm, languages: ['sco', 'swe'])
+        create(:firm, languages: ['nor', 'swe'])
+        expect(Firm.languages_used).to eq(['nor', 'sco', 'swe'])
+      end
+    end
+  end
+
   describe 'default behaviour' do
     it 'sets ethical_investing_flag to false' do
       expect(Firm.new.ethical_investing_flag).to be_falsey


### PR DESCRIPTION
The languages_used method has been introduced to allow us to populate a user editable search filter within the rad_consumer codebase. 

The filter should only contain languages that have been selected by firms/trading_names.