### PR TITLE
[DEV APPROVED] Making adviser fields accessible from elastic search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.105)
+    mas-rad_core (0.0.106)
       active_model_serializers
       geocoder
       httpclient

--- a/app/serializers/adviser_serializer.rb
+++ b/app/serializers/adviser_serializer.rb
@@ -1,7 +1,7 @@
 class AdviserSerializer < ActiveModel::Serializer
   self.root = false
 
-  attributes :_id, :name, :postcode, :range, :location, :range_location
+  attributes :_id, :name, :postcode, :range, :location, :range_location, :qualification_ids, :accreditation_ids
 
   def _id
     object.id

--- a/lib/mas/adviser_result.rb
+++ b/lib/mas/adviser_result.rb
@@ -1,5 +1,6 @@
 class AdviserResult
   attr_reader :id, :name, :postcode, :range, :location
+  attr_accessor :distance
 
   def initialize(data)
     @id       = data['_id']

--- a/lib/mas/adviser_result.rb
+++ b/lib/mas/adviser_result.rb
@@ -1,9 +1,10 @@
 class AdviserResult
-  attr_reader :id, :name, :range, :location
+  attr_reader :id, :name, :postcode, :range, :location
 
   def initialize(data)
     @id       = data['_id']
     @name     = data['name']
+    @postcode = data['postcode']
     @range    = data['range']
     @location = Location.new data['location']['lat'], data['location']['lon']
   end

--- a/lib/mas/adviser_result.rb
+++ b/lib/mas/adviser_result.rb
@@ -1,5 +1,5 @@
 class AdviserResult
-  attr_reader :id, :name, :postcode, :range, :location
+  attr_reader :id, :name, :postcode, :range, :location, :qualification_ids, :accreditation_ids
   attr_accessor :distance
 
   def initialize(data)
@@ -8,5 +8,7 @@ class AdviserResult
     @postcode = data['postcode']
     @range    = data['range']
     @location = Location.new data['location']['lat'], data['location']['lon']
+    @qualification_ids = data['qualification_ids']
+    @accreditation_ids = data['accreditation_ids']
   end
 end

--- a/lib/mas/office_result.rb
+++ b/lib/mas/office_result.rb
@@ -3,6 +3,8 @@ class OfficeResult
               :address_county, :address_postcode, :email_address,
               :telephone_number, :disabled_access, :location
 
+  attr_accessor :distance
+
   def initialize(data)
     @id               = data['_id']
     @address_line_one = data['address_line_one']

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.105'
+    VERSION = '0.0.106'
   end
 end

--- a/spec/lib/mas/adviser_result_spec.rb
+++ b/spec/lib/mas/adviser_result_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe AdviserResult do
     {
       '_id'      => 123,
       'name'     => 'Mandy Advici',
+      'postcode' => 'EC1N 2TD',
       'range'    => 50,
       'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 }
     }
@@ -17,6 +18,10 @@ RSpec.describe AdviserResult do
 
     it 'maps the name' do
       expect(subject.name).to eq('Mandy Advici')
+    end
+
+    it 'maps the postcode' do
+      expect(subject.postcode).to eq('EC1N 2TD')
     end
 
     it 'maps the range' do

--- a/spec/lib/mas/adviser_result_spec.rb
+++ b/spec/lib/mas/adviser_result_spec.rb
@@ -32,5 +32,10 @@ RSpec.describe AdviserResult do
       expect(subject.location.latitude).to eq(51.5180697)
       expect(subject.location.longitude).to eq(-0.1085203)
     end
+
+    it 'is able to store distance during geosorting' do
+      subject.distance = 15
+      expect(subject.distance).to eql(15)
+    end
   end
 end

--- a/spec/lib/mas/adviser_result_spec.rb
+++ b/spec/lib/mas/adviser_result_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe AdviserResult do
       'name'     => 'Mandy Advici',
       'postcode' => 'EC1N 2TD',
       'range'    => 50,
-      'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 }
+      'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 },
+      'qualification_ids' => [1,2,3,4,5],
+      'accreditation_ids' => [2,3,4]
     }
   }
 
@@ -37,5 +39,14 @@ RSpec.describe AdviserResult do
       subject.distance = 15
       expect(subject.distance).to eql(15)
     end
+
+    it 'maps qualification_ids' do
+      expect(subject.qualification_ids).to eq([1,2,3,4,5])
+    end
+
+    it 'maps accreditation_ids' do
+      expect(subject.accreditation_ids).to eq([2,3,4])
+    end
+
   end
 end

--- a/spec/lib/mas/office_result_spec.rb
+++ b/spec/lib/mas/office_result_spec.rb
@@ -33,4 +33,8 @@ RSpec.describe OfficeResult do
     end
   end
 
+  it 'is able to store distance during geosorting' do
+    subject.distance = 15
+    expect(subject.distance).to eql(15)
+  end
 end

--- a/spec/serializers/adviser_serializer_spec.rb
+++ b/spec/serializers/adviser_serializer_spec.rb
@@ -29,5 +29,29 @@ RSpec.describe AdviserSerializer do
       expect(subject[:range_location][:coordinates]).to eq([adviser.longitude, adviser.latitude])
       expect(subject[:range_location][:radius]).to eq('650miles')
     end
+
+    context 'qualifications' do
+      let(:qualifications) { [
+        Qualification.create(id: 1, order: 1, name: 'First Qualification'),
+        Qualification.create(id: 2, order: 2, name: 'Second Qualification')
+      ] }
+      let(:adviser) { create(:adviser, qualifications: qualifications ) }
+
+      it 'exposes `qualification_ids`' do
+        expect(subject[:qualification_ids]).to eq([qualifications.first.id, qualifications.last.id])
+      end
+    end
+
+    context 'accreditations' do
+      let(:accreditations) { [
+        Accreditation.create!(id: 1, name: 'First Accreditation', order: 1),
+        Accreditation.create!(id: 2, name: 'Second Accreditation', order: 2)
+      ] }
+      let(:adviser) { create(:adviser, accreditations: accreditations ) }
+
+      it 'exposes `qualification_ids`' do
+        expect(subject[:accreditation_ids]).to eq([accreditations.first.id, accreditations.last.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR makes a number of pieces of info available for the adviser profile within rad_consumer from elastic search.

1: The postcode on the adviser result.
2: The distance which is from the searched postcode, this field has been added to both adviser and office result objects.

Next we are adding the advisers 
1: qualification 
2: and accreditations 
to elastic search and retrieve them from elastic search for display using the adviser result object.