### PR TITLE
Bug fix: telephone number not showing for any remote firms

### DIFF
--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -22,7 +22,8 @@ class FirmResult
     :adviser_qualification_ids,
     :ethical_investing_flag,
     :sharia_investing_flag,
-    :languages
+    :languages,
+    :telephone_number
   ]
 
   TYPES_OF_ADVICE_FIELDS = [
@@ -86,12 +87,6 @@ class FirmResult
 
   def minimum_pot_size?
     minimum_pot_size_id > LESS_THAN_FIFTY_K_ID
-  end
-
-  def telephone_number
-    return nil unless @telephone_number
-
-    UKPhoneNumbers.format(@telephone_number)
   end
 
   alias :free_initial_meeting? :free_initial_meeting

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe FirmResult do
 
     describe '#telephone_number' do
       context 'when present' do
-        it 'correctly formatted' do
-          expect(subject.telephone_number).to eq('020 8595 2346')
+        it 'is returned' do
+          expect(subject.telephone_number).to eq('02085952346')
         end
       end
     end


### PR DESCRIPTION
The `FirmResult#telephone_number` method is obsolete. It should have been deleted as part of https://github.com/moneyadviceservice/mas-rad_core/pull/146. But we missed it because telephone numbers only come from offices now. But in the rad_consumer the remote firms still seems to get their telephone number from the FirmResult object.

Essentially this was causing phone numbers for remote firms not to appear as they are now pre-formatted in ElasticSearch and UKPhoneNumbers (Gem) doesn't cope with input numbers containing spaces and returns nil.

So instead we just expose the telephone number attribute directly.