### PR TITLE
Migrate session from cookie to db

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.106)
+    mas-rad_core (0.0.107)
       active_model_serializers
       geocoder
       httpclient

--- a/db/migrate/20160317103053_add_sessions_table.rb
+++ b/db/migrate/20160317103053_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :rad_consumer_sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :rad_consumer_sessions, :session_id, :unique => true
+    add_index :rad_consumer_sessions, :updated_at
+  end
+end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.106'
+    VERSION = '0.0.107'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160222091312) do
+ActiveRecord::Schema.define(version: 20160317103053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -260,6 +260,16 @@ ActiveRecord::Schema.define(version: 20160222091312) do
     t.datetime "updated_at",             null: false
     t.integer  "order",      default: 0, null: false
   end
+
+  create_table "rad_consumer_sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "rad_consumer_sessions", ["session_id"], name: "index_rad_consumer_sessions_on_session_id", unique: true, using: :btree
+  add_index "rad_consumer_sessions", ["updated_at"], name: "index_rad_consumer_sessions_on_updated_at", using: :btree
 
   create_table "snapshots", force: :cascade do |t|
     t.integer  "firms_with_no_minimum_fee"


### PR DESCRIPTION
We found when adding the 'Recently Visited Firms' functionality in rad_consumer that the data being added to the cookie could be too much.

We did try and trim down the amount of data being added to the cookie with this [PR](https://github.com/moneyadviceservice/rad_consumer/pull/288) however if the amount of data grew we'd have the same issue.

Migrating to having the session within the DB seemed like the more robust solution.