### PR TITLE
Add Workplace financial advice groundwork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.107)
+    mas-rad_core (0.0.108)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/snapshot/firm_queries.rb
+++ b/app/models/snapshot/firm_queries.rb
@@ -82,6 +82,10 @@ module Snapshot::FirmQueries
     publishable_firms.select { |f| f.ethical_investing_flag? }
   end
 
+  def query_firms_providing_workplace_financial_advice
+    publishable_firms.select { |f| f.workplace_financial_advice_flag? }
+  end
+
   def query_firms_providing_sharia_investing
     publishable_firms.select { |f| f.sharia_investing_flag? }
   end

--- a/app/models/snapshot/metrics_in_order.rb
+++ b/app/models/snapshot/metrics_in_order.rb
@@ -22,6 +22,7 @@ module Snapshot::MetricsInOrder
       :firms_providing_wills_and_probate,
       :firms_providing_ethical_investing,
       :firms_providing_sharia_investing,
+      :firms_providing_workplace_financial_advice,
       :firms_offering_languages_other_than_english,
       :offices_with_disabled_access,
       :registered_advisers,

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -22,6 +22,7 @@ class FirmSerializer < ActiveModel::Serializer
     :adviser_accreditation_ids,
     :ethical_investing_flag,
     :sharia_investing_flag,
+    :workplace_financial_advice_flag,
     :languages
 
   has_many :advisers

--- a/db/migrate/20160325155550_add_workplace_financial_advice_to_firms.rb
+++ b/db/migrate/20160325155550_add_workplace_financial_advice_to_firms.rb
@@ -1,0 +1,5 @@
+class AddWorkplaceFinancialAdviceToFirms < ActiveRecord::Migration
+  def change
+    add_column :firms, :workplace_financial_advice_flag, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20160328130032_add_workplace_financial_advice_to_snapshots.rb
+++ b/db/migrate/20160328130032_add_workplace_financial_advice_to_snapshots.rb
@@ -1,0 +1,5 @@
+class AddWorkplaceFinancialAdviceToSnapshots < ActiveRecord::Migration
+  def change
+    add_column :snapshots, :firms_providing_workplace_financial_advice, :integer, default: 0
+  end
+end

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -22,6 +22,7 @@ class FirmResult
     :adviser_qualification_ids,
     :ethical_investing_flag,
     :sharia_investing_flag,
+    :workplace_financial_advice_flag,
     :languages,
     :telephone_number
   ]

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.107'
+    VERSION = '0.0.108'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160317103053) do
+ActiveRecord::Schema.define(version: 20160325155550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20160317103053) do
     t.boolean  "sharia_investing_flag",                    default: false, null: false
     t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
+    t.boolean  "workplace_financial_advice_flag",          default: false, null: false
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160325155550) do
+ActiveRecord::Schema.define(version: 20160328130032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -331,8 +331,9 @@ ActiveRecord::Schema.define(version: 20160325155550) do
     t.integer  "advisers_part_of_ci_securities_and_investments"
     t.integer  "advisers_part_of_cfa_institute"
     t.integer  "advisers_part_of_chartered_accountants"
-    t.datetime "created_at",                                                 null: false
-    t.datetime "updated_at",                                                 null: false
+    t.datetime "created_at",                                                             null: false
+    t.datetime "updated_at",                                                             null: false
+    t.integer  "firms_providing_workplace_financial_advice",                 default: 0
   end
 
 end

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe FirmResult do
         'adviser_qualification_ids' => [3],
         'ethical_investing_flag' => true,
         'sharia_investing_flag' => false,
+        'workplace_financial_advice_flag' => true,
         'languages' => %w(spa por aae),
         'advisers' => [
           {
@@ -121,6 +122,10 @@ RSpec.describe FirmResult do
 
     it 'maps the "sharia_investing_flag"' do
       expect(subject.sharia_investing_flag).to eq(false)
+    end
+
+    it 'maps the "workplace_financial_advice_flag"' do
+      expect(subject.workplace_financial_advice_flag).to eq(true)
     end
 
     it 'maps the "languages"' do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Firm do
       expect(Firm.new.sharia_investing_flag).to be_falsey
     end
 
+    it 'sets workplace_financial_advice_flag to false' do
+      expect(Firm.new.workplace_financial_advice_flag).to be_falsey
+    end
+
     it 'sets languages to an array with empty set' do
       expect(Firm.new.languages).to eq []
     end

--- a/spec/models/snapshot_spec.rb
+++ b/spec/models/snapshot_spec.rb
@@ -276,6 +276,16 @@ RSpec.describe Snapshot do
     it { expect(subject.query_firms_providing_sharia_investing.count).to eq(2) }
   end
 
+  describe '#query_firms_providing_workplace_financial_advice' do
+    before do
+      FactoryGirl.create(:firm, workplace_financial_advice_flag: true)
+      FactoryGirl.create(:firm, workplace_financial_advice_flag: false)
+      FactoryGirl.create(:firm, workplace_financial_advice_flag: true)
+    end
+
+    it { expect(subject.query_firms_providing_workplace_financial_advice.count).to eq(2) }
+  end
+
   describe '#query_firms_offering_languages_other_than_english' do
     before do
       FactoryGirl.create(:firm, languages: [])
@@ -700,6 +710,7 @@ RSpec.describe Snapshot do
         :firms_providing_wills_and_probate,
         :firms_providing_ethical_investing,
         :firms_providing_sharia_investing,
+        :firms_providing_workplace_financial_advice,
         :firms_offering_languages_other_than_english,
         :offices_with_disabled_access,
         :registered_advisers,

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe FirmSerializer do
       expect(subject[:sharia_investing_flag]).to eql(firm.sharia_investing_flag)
     end
 
+    it 'exposes "workplace_financial_advice_flag"' do
+      expect(subject[:workplace_financial_advice_flag]).to eql(firm.workplace_financial_advice_flag)
+    end
+
     describe 'advisers' do
       before { create(:adviser, firm: firm, latitude: nil, longitude: nil) }
 


### PR DESCRIPTION
This PR allows us to do a number of things related to :workplace_financial_advice :

- In the [RAD PR](https://github.com/moneyadviceservice/rad/pull/387) we capture if a firm provides :workplace_financial_advice.
- In the [RAD PR](https://github.com/moneyadviceservice/rad/pull/387) we also have a metrics (snapshot) report which captures :workplace_financial_advice.
- In [rad_consumer PR](https://github.com/moneyadviceservice/rad_consumer/pull/294) we allow the user to filter their search based on :workplace_finanacial_advice.


