### PR TITLE
[DEV APPROVED]Add 'non uk residents' groundwork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.108)
+    mas-rad_core (0.0.109)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/snapshot/firm_queries.rb
+++ b/app/models/snapshot/firm_queries.rb
@@ -86,6 +86,10 @@ module Snapshot::FirmQueries
     publishable_firms.select { |f| f.workplace_financial_advice_flag? }
   end
 
+  def query_firms_providing_non_uk_residents
+    publishable_firms.select { |f| f.non_uk_residents_flag? }
+  end
+
   def query_firms_providing_sharia_investing
     publishable_firms.select { |f| f.sharia_investing_flag? }
   end

--- a/app/models/snapshot/metrics_in_order.rb
+++ b/app/models/snapshot/metrics_in_order.rb
@@ -23,6 +23,7 @@ module Snapshot::MetricsInOrder
       :firms_providing_ethical_investing,
       :firms_providing_sharia_investing,
       :firms_providing_workplace_financial_advice,
+      :firms_providing_non_uk_residents,
       :firms_offering_languages_other_than_english,
       :offices_with_disabled_access,
       :registered_advisers,

--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -23,6 +23,7 @@ class FirmSerializer < ActiveModel::Serializer
     :ethical_investing_flag,
     :sharia_investing_flag,
     :workplace_financial_advice_flag,
+    :non_uk_residents_flag,
     :languages
 
   has_many :advisers

--- a/db/migrate/20160329105636_add_non_uk_residents_to_firms.rb
+++ b/db/migrate/20160329105636_add_non_uk_residents_to_firms.rb
@@ -1,0 +1,5 @@
+class AddNonUkResidentsToFirms < ActiveRecord::Migration
+  def change
+    add_column :firms, :non_uk_residents_flag, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20160329110348_add_add_non_uk_residents_to_snapshots.rb
+++ b/db/migrate/20160329110348_add_add_non_uk_residents_to_snapshots.rb
@@ -1,0 +1,5 @@
+class AddAddNonUkResidentsToSnapshots < ActiveRecord::Migration
+  def change
+    add_column :snapshots, :firms_providing_non_uk_residents, :integer, default: 0
+  end
+end

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -23,6 +23,7 @@ class FirmResult
     :ethical_investing_flag,
     :sharia_investing_flag,
     :workplace_financial_advice_flag,
+    :non_uk_residents_flag,
     :languages,
     :telephone_number
   ]

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.108'
+    VERSION = '0.0.109'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329105636) do
+ActiveRecord::Schema.define(version: 20160329110348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,6 +335,7 @@ ActiveRecord::Schema.define(version: 20160329105636) do
     t.datetime "created_at",                                                             null: false
     t.datetime "updated_at",                                                             null: false
     t.integer  "firms_providing_workplace_financial_advice",                 default: 0
+    t.integer  "firms_providing_non_uk_residents",                           default: 0
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160328130032) do
+ActiveRecord::Schema.define(version: 20160329105636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20160328130032) do
     t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
     t.boolean  "workplace_financial_advice_flag",          default: false, null: false
+    t.boolean  "non_uk_residents_flag",                    default: false, null: false
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe FirmResult do
         'ethical_investing_flag' => true,
         'sharia_investing_flag' => false,
         'workplace_financial_advice_flag' => true,
+        'non_uk_residents_flag' => true,
         'languages' => %w(spa por aae),
         'advisers' => [
           {
@@ -126,6 +127,10 @@ RSpec.describe FirmResult do
 
     it 'maps the "workplace_financial_advice_flag"' do
       expect(subject.workplace_financial_advice_flag).to eq(true)
+    end
+
+    it 'maps the "non_uk_residents_flag"' do
+      expect(subject.non_uk_residents_flag).to eq(true)
     end
 
     it 'maps the "languages"' do

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Firm do
       expect(Firm.new.workplace_financial_advice_flag).to be_falsey
     end
 
+    it 'sets non_uk_residents_flag to false' do
+      expect(Firm.new.non_uk_residents_flag).to be_falsey
+    end
+
     it 'sets languages to an array with empty set' do
       expect(Firm.new.languages).to eq []
     end

--- a/spec/models/snapshot_spec.rb
+++ b/spec/models/snapshot_spec.rb
@@ -286,6 +286,16 @@ RSpec.describe Snapshot do
     it { expect(subject.query_firms_providing_workplace_financial_advice.count).to eq(2) }
   end
 
+  describe '#query_firms_providing_non_uk_residents' do
+    before do
+      FactoryGirl.create(:firm, non_uk_residents_flag: false)
+      FactoryGirl.create(:firm, non_uk_residents_flag: true)
+      FactoryGirl.create(:firm, non_uk_residents_flag: true)
+    end
+
+    it { expect(subject.query_firms_providing_non_uk_residents.count).to eq(2) }
+  end
+
   describe '#query_firms_offering_languages_other_than_english' do
     before do
       FactoryGirl.create(:firm, languages: [])
@@ -711,6 +721,7 @@ RSpec.describe Snapshot do
         :firms_providing_ethical_investing,
         :firms_providing_sharia_investing,
         :firms_providing_workplace_financial_advice,
+        :firms_providing_non_uk_residents,
         :firms_offering_languages_other_than_english,
         :offices_with_disabled_access,
         :registered_advisers,

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe FirmSerializer do
       expect(subject[:workplace_financial_advice_flag]).to eql(firm.workplace_financial_advice_flag)
     end
 
+    it 'exposes "non_uk_residents_flag"' do
+      expect(subject[:non_uk_residents_flag]).to eql(firm.non_uk_residents_flag)
+    end
+
     describe 'advisers' do
       before { create(:adviser, firm: firm, latitude: nil, longitude: nil) }
 


### PR DESCRIPTION
This PR allows us to do a number of things related to :non_uk_residents :

- In the [RAD PR](https://github.com/moneyadviceservice/rad/pull/389) we will capture if a firm provides advice to :non_uk_residents
- In the [RAD PR](https://github.com/moneyadviceservice/rad/pull/389) we also have a metrics (snapshot) report which captures :non_uk_residents.
- In rad_consumer we allow the user to filter their search based on :non_uk_residents.