### PR TITLE
[WIP] Add temp import_tables for FCA Import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mas-rad_core (0.0.109)
+    mas-rad_core (0.0.110)
       active_model_serializers
       geocoder
       httpclient

--- a/app/models/lookup/import/adviser.rb
+++ b/app/models/lookup/import/adviser.rb
@@ -15,6 +15,12 @@ module Lookup
       def self.truncate_sql
         "TRUNCATE #{table_name};"
       end
+
+      def self.import_uploaded_fca_data
+        lookup_class = Lookup::Adviser
+        lookup_class.delete_all
+        ActiveRecord::Base.connection.execute("INSERT INTO #{lookup_class.table_name} (SELECT * FROM #{table_name});")
+      end
     end
   end
 end

--- a/app/models/lookup/import/adviser.rb
+++ b/app/models/lookup/import/adviser.rb
@@ -7,6 +7,10 @@ module Lookup
       def self.table_name
         "lookup_import_#{super}"
       end
+
+      def self.fca_import_copy_statement
+        "COPY #{table_name} (reference_number, name, created_at, updated_at) FROM stdin;"
+      end
     end
   end
 end

--- a/app/models/lookup/import/adviser.rb
+++ b/app/models/lookup/import/adviser.rb
@@ -11,6 +11,10 @@ module Lookup
       def self.fca_import_copy_statement
         "COPY #{table_name} (reference_number, name, created_at, updated_at) FROM stdin;"
       end
+
+      def self.truncate_sql
+        "TRUNCATE #{table_name};"
+      end
     end
   end
 end

--- a/app/models/lookup/import/adviser.rb
+++ b/app/models/lookup/import/adviser.rb
@@ -1,0 +1,12 @@
+module Lookup
+  module Import
+    class Adviser < ActiveRecord::Base
+      validates_length_of   :reference_number, is: 8
+      validates_presence_of :name
+
+      def self.table_name
+        "lookup_import_#{super}"
+      end
+    end
+  end
+end

--- a/app/models/lookup/import/firm.rb
+++ b/app/models/lookup/import/firm.rb
@@ -1,0 +1,15 @@
+module Lookup
+  module Import
+    class Firm < ActiveRecord::Base
+      has_many :subsidiaries, primary_key: :fca_number, foreign_key: :fca_number
+
+      validates :fca_number,
+        length: { is: 6 },
+        numericality: { only_integer: true }
+
+      def self.table_name
+        "lookup_import_#{super}"
+      end
+    end
+  end
+end

--- a/app/models/lookup/import/firm.rb
+++ b/app/models/lookup/import/firm.rb
@@ -1,14 +1,16 @@
 module Lookup
   module Import
     class Firm < ActiveRecord::Base
-      has_many :subsidiaries, primary_key: :fca_number, foreign_key: :fca_number
-
       validates :fca_number,
         length: { is: 6 },
         numericality: { only_integer: true }
 
       def self.table_name
         "lookup_import_#{super}"
+      end
+
+      def self.fca_import_copy_statement
+        "COPY #{self.table_name} (fca_number, registered_name, created_at, updated_at) FROM stdin;"
       end
     end
   end

--- a/app/models/lookup/import/firm.rb
+++ b/app/models/lookup/import/firm.rb
@@ -12,6 +12,10 @@ module Lookup
       def self.fca_import_copy_statement
         "COPY #{self.table_name} (fca_number, registered_name, created_at, updated_at) FROM stdin;"
       end
+
+      def self.truncate_sql
+        "TRUNCATE #{table_name};"
+      end
     end
   end
 end

--- a/app/models/lookup/import/firm.rb
+++ b/app/models/lookup/import/firm.rb
@@ -16,6 +16,12 @@ module Lookup
       def self.truncate_sql
         "TRUNCATE #{table_name};"
       end
+
+      def self.import_uploaded_fca_data
+        lookup_class = Lookup::Firm
+        lookup_class.delete_all
+        ActiveRecord::Base.connection.execute("INSERT INTO #{lookup_class.table_name} (SELECT * FROM #{table_name});")
+      end
     end
   end
 end

--- a/app/models/lookup/import/subsidiary.rb
+++ b/app/models/lookup/import/subsidiary.rb
@@ -12,6 +12,10 @@ module Lookup
       def self.fca_import_copy_statement
         "COPY #{table_name} (fca_number, name, created_at, updated_at) FROM stdin;"
       end
+
+      def self.truncate_sql
+        "TRUNCATE #{table_name};"
+      end
     end
   end
 end

--- a/app/models/lookup/import/subsidiary.rb
+++ b/app/models/lookup/import/subsidiary.rb
@@ -16,6 +16,12 @@ module Lookup
       def self.truncate_sql
         "TRUNCATE #{table_name};"
       end
+
+      def self.import_uploaded_fca_data
+        lookup_class = Lookup::Subsidiary
+        lookup_class.delete_all
+        ActiveRecord::Base.connection.execute("INSERT INTO #{lookup_class.table_name} (SELECT * FROM #{table_name});")
+      end
     end
   end
 end

--- a/app/models/lookup/import/subsidiary.rb
+++ b/app/models/lookup/import/subsidiary.rb
@@ -8,6 +8,10 @@ module Lookup
       def self.table_name
         "lookup_import_#{super}"
       end
+
+      def self.fca_import_copy_statement
+        "COPY #{table_name} (fca_number, name, created_at, updated_at) FROM stdin;"
+      end
     end
   end
 end

--- a/app/models/lookup/import/subsidiary.rb
+++ b/app/models/lookup/import/subsidiary.rb
@@ -1,0 +1,13 @@
+module Lookup
+  module Import
+    class Subsidiary < ActiveRecord::Base
+      validates :fca_number,
+        length: { is: 6 },
+        numericality: { only_integer: true }
+
+      def self.table_name
+        "lookup_import_#{super}"
+      end
+    end
+  end
+end

--- a/db/migrate/20160420134053_create_import_tables.rb
+++ b/db/migrate/20160420134053_create_import_tables.rb
@@ -1,0 +1,25 @@
+class CreateImportTables < ActiveRecord::Migration
+  def change
+    create_table :lookup_import_firms do |t|
+      t.integer :fca_number, null: false
+      t.string  :registered_name, null: false, default: ''
+      t.index   :fca_number, unique: true
+
+      t.timestamps null: false
+    end
+
+    create_table :lookup_import_subsidiaries do |t|
+      t.integer :fca_number, null: false, index: true
+      t.string  :name, null: false, default: ''
+
+      t.timestamps null: false
+    end
+
+    create_table :lookup_import_advisers do |t|
+      t.string :reference_number, null: false, unique: true, length: 8
+      t.string :name, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/lib/mas/rad_core/version.rb
+++ b/lib/mas/rad_core/version.rb
@@ -1,5 +1,5 @@
 module MAS
   module RadCore
-    VERSION = '0.0.109'
+    VERSION = '0.0.110'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329110348) do
+ActiveRecord::Schema.define(version: 20160420134053) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,31 @@ ActiveRecord::Schema.define(version: 20160329110348) do
   end
 
   add_index "lookup_firms", ["fca_number"], name: "index_lookup_firms_on_fca_number", unique: true, using: :btree
+
+  create_table "lookup_import_advisers", force: :cascade do |t|
+    t.string   "reference_number", null: false
+    t.string   "name",             null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
+
+  create_table "lookup_import_firms", force: :cascade do |t|
+    t.integer  "fca_number",                   null: false
+    t.string   "registered_name", default: "", null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
+
+  add_index "lookup_import_firms", ["fca_number"], name: "index_lookup_import_firms_on_fca_number", unique: true, using: :btree
+
+  create_table "lookup_import_subsidiaries", force: :cascade do |t|
+    t.integer  "fca_number",              null: false
+    t.string   "name",       default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  add_index "lookup_import_subsidiaries", ["fca_number"], name: "index_lookup_import_subsidiaries_on_fca_number", using: :btree
 
   create_table "lookup_subsidiaries", force: :cascade do |t|
     t.integer  "fca_number",              null: false

--- a/spec/models/lookup/import/adviser_spec.rb
+++ b/spec/models/lookup/import/adviser_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Lookup::Import::Adviser do
+  describe '#table_name' do
+    specify { expect(described_class.table_name).to eql('lookup_import_advisers') }
+  end
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(
+        described_class.new(reference_number: 'ABC12345', name: 'Miss Adviser')
+      ).to be_valid
+    end
+
+    it 'is invalid without a name' do
+      expect(
+        described_class.new(reference_number: 'ABC12345', name: nil)
+      ).to be_invalid
+    end
+
+    describe 'FCA Number rules' do
+      it 'does not accept numeric' do
+        expect(described_class.new(reference_number: 12345678)).to_not be_valid
+      end
+
+      it 'accepts only 8 characters' do
+        expect(described_class.new(reference_number: '123456789')).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/lookup/import/firm_spec.rb
+++ b/spec/models/lookup/import/firm_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Lookup::Import::Firm do
+  describe '#table_name' do
+    specify { expect(described_class.table_name).to eql('lookup_import_firms') }
+  end
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(
+        described_class.new(fca_number: 123456, registered_name: 'Ben Lovell Ltd')
+      ).to be_valid
+    end
+
+    describe 'FCA Number rules' do
+      it 'accepts numeric' do
+        expect(described_class.new(fca_number: '123A45')).to_not be_valid
+      end
+
+      it 'accepts only 6 digits' do
+        expect(described_class.new(fca_number: 1234567)).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/lookup/import/subsidiary_spec.rb
+++ b/spec/models/lookup/import/subsidiary_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Lookup::Import::Subsidiary do
+  describe '#table_name' do
+    specify { expect(described_class.table_name).to eql('lookup_import_subsidiaries') }
+  end
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(
+        described_class.new(fca_number: 123456, name: 'Ben Lovell Ltd')
+      ).to be_valid
+    end
+
+    describe 'FCA Number rules' do
+      it 'accepts numeric' do
+        expect(described_class.new(fca_number: '123A45')).to_not be_valid
+      end
+
+      it 'accepts only 6 digits' do
+        expect(described_class.new(fca_number: 1234567)).to_not be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces three tables to facilitate the migration of the fca import script to being something that can be run from within the admin area of RAD. 

This will allow Sandrine to run the import rather than take up dev time.
