### PR TITLE
RAD Admin -Fix "advisors can't seem to register offices"

### DIFF
--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -67,8 +67,13 @@ class Office < ActiveRecord::Base
     return format_telephone_number(cleanup_telephone_number(super))
   end
 
+  # The Geocodable interface expect an object that responds to
+  # Geocodable#full_street_address. So, to respect the interface,
+  # we created internally the method postcode_only_address,
+  # to reflect what this object returns differently from the others.
+  #
   def full_street_address
-    [address_line_one, address_line_two, address_postcode, 'United Kingdom'].reject(&:blank?).join(', ')
+    postcode_only_address
   end
 
   def has_address_changes?
@@ -91,6 +96,10 @@ class Office < ActiveRecord::Base
   end
 
   private
+
+  def postcode_only_address
+    [address_postcode, 'United Kingdom'].join(', ')
+  end
 
   def postcode_is_valid
     if address_postcode.nil? || !UKPostcode.parse(address_postcode).full_valid?

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -334,18 +334,18 @@ RSpec.describe Office do
   describe '#full_street_address' do
     subject { office.full_street_address }
 
-    it { is_expected.to eql "#{office.address_line_one}, #{office.address_line_two}, #{office.address_postcode}, United Kingdom"}
+    it { is_expected.to eql "#{office.address_postcode}, United Kingdom"}
 
     context 'when line two is nil' do
       before { office.address_line_two = nil }
 
-      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
+      it { is_expected.to eql "#{office.address_postcode}, United Kingdom"}
     end
 
     context 'when line two is an empty string' do
       before { office.address_line_two = '' }
 
-      it { is_expected.to eql "#{office.address_line_one}, #{office.address_postcode}, United Kingdom"}
+      it { is_expected.to eql "#{office.address_postcode}, United Kingdom"}
     end
   end
 end


### PR DESCRIPTION
# The problem

When the user add ambiguos address with the building name on it, the system returns the validation error message:

```
1. Address could not be found by the mapping service.
We could not find the coordinates of your office address to plot it on the map in the directory.
Please check and try again. Ensure that you have put the street address, including building number, in the ‘Street address’ field and, if you have a building name enter this into the  separate ‘Building name’ field.
If the details are correct and still cannot be found, please contact RADenquiries@moneyadviceservice.org.uk for assistance.
```

So the main problem that Google is not returning latitude and longitude for ambiguous address
that has building name on the address. This is a limitation of the Geocoding API listed here:

https://maps-apis.googleblog.com/2016/11/address-geocoding-in-google-maps-apis.html

# Possible solutions

So the possible solutions were:

* Change to the Places API like suggested on the link above;
* Change to Bing
* Add a field name called Building name
* Just send the postcode to validate the address on Google.

After conversation with the stakeholders, they asked to just send the postcode instead the address line 1 and address line 2.