### PR TITLE
[WIP] - Add compatibility on elastic search 2.x

### DIFF
--- a/app/serializers/firm_serializer.rb
+++ b/app/serializers/firm_serializer.rb
@@ -1,8 +1,7 @@
 class FirmSerializer < ActiveModel::Serializer
   self.root = false
 
-  attributes :_id,
-    :registered_name,
+  attributes :registered_name,
     :postcode_searchable,
     :telephone_number,
     :website_address,

--- a/lib/mas/elastic_search_client.rb
+++ b/lib/mas/elastic_search_client.rb
@@ -7,19 +7,27 @@ class ElasticSearchClient
   end
 
   def store(path, json)
+    log("PUT /#{path}\nRequest Body: #{json}")
+
     res = http.put(uri_for(path), JSON.generate(json))
     res.ok?
   end
 
   def search(path, json = '')
+    log("POST /#{path}\nRequest Body: #{json}")
+
     http.post(uri_for(path), json)
   end
 
   def find(path)
+    log("GET /#{path}")
+
     http.get(uri_for(path))
   end
 
   def delete(path)
+    log("DELETE /#{path}")
+
     res = http.delete(uri_for(path))
     res.ok?
   end
@@ -32,6 +40,10 @@ class ElasticSearchClient
         c.set_auth(server, username, password) if authenticate?
       end
     end
+  end
+
+  def log(message)
+    Rails.logger.debug("ElasticSearch Request: #{message}")
   end
 
   def authenticate?

--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -47,7 +47,7 @@ class FirmResult
 
   def initialize(data)
     source = data['_source']
-    @id    = source['_id']
+    @id    = data['_id'].to_i
     @name  = source['registered_name']
     @advisers         = source['advisers']
     @total_advisers   = source['advisers'].count

--- a/spec/lib/mas/firm_repository_spec.rb
+++ b/spec/lib/mas/firm_repository_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe FirmRepository do
       let(:firm) { create(:firm) }
 
       it 'delegates to the configured client' do
-        expect(client).to receive(:store).with(/firms\/\d+/, hash_including(:_id))
+        expect(client).to receive(:store)
+          .with(/firms\/#{firm.id}/, FirmSerializer.new(firm).as_json)
 
         described_class.new(client_class).store(firm)
       end

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe FirmResult do
       '_id'     => '1',
       '_score'  => nil,
       '_source' => {
-        '_id' => 1,
         'registered_name' => 'Financial Advice 1 Ltd.',
         'postcode_searchable' => true,
         'address_line_one' => '64 Somewhere',
@@ -78,7 +77,7 @@ RSpec.describe FirmResult do
 
   describe 'the deserialized result' do
     it 'maps the `id`' do
-      expect(subject.id).to eq(1)
+      expect(subject.id).to be(1)
     end
 
     it 'maps the `name`' do

--- a/spec/serializers/firm_serializer_spec.rb
+++ b/spec/serializers/firm_serializer_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe FirmSerializer do
   describe 'the serialized json' do
     subject { described_class.new(firm).as_json }
 
-    it 'exposes `_id`' do
-      expect(subject[:_id]).to eql(firm.id)
-    end
-
     it 'exposes `registered_name`' do
       expect(subject[:registered_name]).to eql(firm.registered_name)
     end


### PR DESCRIPTION
With elastic 2.0 is not allowed anymore to pass the field _id on the document.
So the first thing we notice when try to index firms was the error on
elastic search:

```
MapperParsingException[Field [_id] is a metadata field and cannot be added
inside a document. Use the index API request parameters.]
```

Since we can pass the id on the resource path when you're creating
the documents **one by one** and **not on bulk** then removing
from source and parsing from the root node makes elastic works in
the same way as before.

## Aditional improvement

In order to facilitate the development of this feature, It was added logs in debug mode every time the app makes a request to elastic search and leave there for the same reason.