### PR TITLE
When sort node is nil returns 0 for closest adviser

### DIFF
--- a/lib/mas/firm_result.rb
+++ b/lib/mas/firm_result.rb
@@ -45,13 +45,15 @@ class FirmResult
     *DIRECTLY_MAPPED_FIELDS,
     *TYPES_OF_ADVICE_FIELDS
 
+  attr_writer :closest_adviser
+
   def initialize(data)
     source = data['_source']
     @id    = source['_id']
     @name  = source['registered_name']
     @advisers         = source['advisers']
     @total_advisers   = source['advisers'].count
-    @closest_adviser  = data['sort'].first
+    @closest_adviser  = data['sort'] ? data['sort'].first : 0
     @telephone_number = source['telephone_number']
     @offices = source['offices']
     @total_offices = source['offices'].count

--- a/spec/lib/mas/firm_result_spec.rb
+++ b/spec/lib/mas/firm_result_spec.rb
@@ -226,10 +226,20 @@ RSpec.describe FirmResult do
     end
 
     describe '#closest_adviser' do
-      before { data['sort'] = [1.23456789, 2.34567890] }
+      context 'when has sort data' do
+        before { data['sort'] = [1.23456789, 2.34567890] }
 
-      it 'returns the first distance' do
-        expect(subject.closest_adviser).to eq(1.23456789)
+        it 'returns the first distance' do
+          expect(subject.closest_adviser).to be(1.23456789)
+        end
+      end
+
+      context 'when does NOT have sort data' do
+        before { data['sort'] = nil }
+
+        it 'returns zero as closest adviser' do
+          expect(subject.closest_adviser).to be(0)
+        end
       end
     end
 


### PR DESCRIPTION
Elastic search don't return the sort node when findin by
firms/:id only by search all /firms/_search url.
Since both request are using the firm result, we need to
add a little flexibility on this particular node.

I included on the same commit the attribute writer for
closest adviser. This makes possible for some other place
I set the closest adviser (when a user passing the distance for example)

This is related to https://github.com/moneyadviceservice/rad_consumer/pull/316