### PR TITLE
[DEV APPROVED] Redis.connect is now replaced by Redis.new

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -5,6 +5,6 @@ if Rails.env.production?
     lookup: :google,
     use_https: true,
     api_key: ENV['GOOGLE_GEOCODER_API_KEY'],
-    cache: Redis.connect(url: ENV['REDISTOGO_URL'])
+    cache: Redis.new(url: ENV['REDISTOGO_URL'])
   )
 end


### PR DESCRIPTION
The previous Gem upgrades had updated the Redis gem to 4.0.1, which no longer has the method `Redis.connect`. Now it is `Redis.new`.

This is loosely connected to https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/4771110243071511547&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/8699/silent but effectively means that the current version of `mas-rad_core` on Rubygems is unusable in production mode.