### PR TITLE
[DEV APPROVED] Fix some warnings - TP8699 

### DIFF
--- a/spec/factories/firm.rb
+++ b/spec/factories/firm.rb
@@ -38,7 +38,7 @@ FactoryGirl.define do
     end
 
     factory :trading_name, aliases: [:subsidiary] do
-      parent factory: Firm
+      parent factory: :firm
     end
 
     factory :firm_with_advisers, traits: [:with_advisers]

--- a/spec/models/firm_spec.rb
+++ b/spec/models/firm_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe Firm do
 
       context 'with a garbage status' do
         it 'throws an exception' do
-          expect { build(:firm, status: :horse) }.to raise_error
+          expect { build(:firm, status: :horse) }.to raise_error(ArgumentError)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'pry'
 Dir[File.join(File.dirname(__FILE__), 'support', '**', '*.rb')].each { |f| require f }
 
 Faker::Config.locale = 'en-GB'
+FactoryGirl.allow_class_lookup = false
 
 ActiveRecord::Migrator.migrations_paths.tap do |paths|
   paths << File.expand_path('../../spec/dummy/db/migrate', __FILE__)


### PR DESCRIPTION
Related to: https://moneyadviceservice.tpondemand.com/entity/8699-rad-upgrade-rails-and-node-packages, in that the gem upgrades introduced the warnings.

Fixes the repetitive test warning in this and the client repositories:

```
DEPRECATION WARNING: Looking up factories by class is deprecated and will be removed in 5.0. Use symbols instead and set FactoryGirl.allow_class_lookup = false. (called from block (4 levels) in <top (required)> at /Users/paul/dev/mas/mas-rad_core/spec/factories/firm.rb:95)

```

Also fixes

```
DEPRECATION WARNING: Looking up factories by class is deprecated and will be removed in 5.0. Use symbols instead and set FactoryGirl.allow_class_lookup = false. (called from block (3 levels) in <top (required)> at /Users/paul/dev/mas/mas-rad_core/spec/models/adviser_spec.rb:253)
DEPRECATION WARNING: Looking up factories by class is deprecated and will be removed in 5.0. Use symbols instead and set FactoryGirl.allow_class_lookup = false. (called from block (3 levels) in <top (required)> at /Users/paul/dev/mas/mas-rad_core/spec/models/adviser_spec.rb:253)
```

The warning about `FactoryGirl` being deprecated in favour of `FactoryBot` is not fixed here as it needs extensive changes to test files here, and in the client repos. It makes sense to fix that as separate PRs, coordinated across all 3 RAD repos.
