### PR TITLE
[WIP] 8802: Fixes serialization and to_json of the Firm model

### DIFF
--- a/lib/mas/firm_repository.rb
+++ b/lib/mas/firm_repository.rb
@@ -7,7 +7,7 @@ class FirmRepository
   end
 
   def store(firm)
-    json = serializer.new(firm).as_json
+    json = serializer.new(firm).as_json(root: false)
     path = "#{firm.model_name.plural}/#{firm.to_param}"
 
     client.store(path, json)


### PR DESCRIPTION
It's not clear which gem exactly caused the issue but this line now returns an object with the serialized firm inside of a top level "firm" key after calling `to_json`.

This was likely introduced as part of the rails upgrade here: #164 but (luckily) the Elasticsearch re-index has not been run.